### PR TITLE
Create a redistributable bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,12 @@
 {
-  "presets": ["es2015-loose", "stage-0", "react"],
-  "plugins": [
-    "transform-decorators-legacy"
-  ]
+  "env": {
+    "development": {
+      "presets": ["es2015-loose", "stage-0", "react"],
+      "plugins": ["transform-decorators-legacy"]
+    },
+    "buildmodule": {
+      "presets": ["es2015-loose-rollup", "stage-0", "react"],
+      "plugins": ["transform-decorators-legacy"]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ npm-debug.log
 .DS_Store
 dist
 lib
+mod
 coverage

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "4.0.6",
   "description": "Official React bindings for Redux",
   "main": "./lib/index.js",
-  "jsnext:main": "./src/index.js",
+  "jsnext:main": "./mod/index.js",
   "scripts": {
     "build:lib": "babel src --out-dir lib",
+    "build:mod": "BABEL_ENV=buildmodule babel src --out-dir mod",
     "build:umd": "webpack src/index.js dist/react-redux.js --config webpack.config.development.js",
     "build:umd:min": "webpack src/index.js dist/react-redux.min.js --config webpack.config.production.js",
-    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
-    "clean": "rimraf lib dist coverage",
+    "build": "npm run build:lib && npm run build:mod && npm run build:umd && npm run build:umd:min",
+    "clean": "rimraf lib mod dist coverage",
     "lint": "eslint src test",
     "prepublish": "npm run clean && npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js",
@@ -23,7 +24,7 @@
   "files": [
     "dist",
     "lib",
-    "src"
+    "mod"
   ],
   "keywords": [
     "react",
@@ -49,6 +50,7 @@
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-decorators-legacy": "^1.2.0",
     "babel-preset-es2015-loose": "^6.1.4",
+    "babel-preset-es2015-loose-rollup": "^7.0.0",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "eslint": "^1.7.1",

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,5 +1,5 @@
-const { Component, PropTypes, Children } = require('react')
-const storeShape = require('../utils/storeShape')
+import { Component, PropTypes, Children } from 'react'
+import storeShape from '../utils/storeShape'
 
 let didWarnAboutReceivingStore = false
 function warnAboutReceivingStore() {
@@ -17,7 +17,7 @@ function warnAboutReceivingStore() {
   )
 }
 
-class Provider extends Component {
+export default class Provider extends Component {
   getChildContext() {
     return { store: this.store }
   }
@@ -49,5 +49,3 @@ Provider.propTypes = {
 Provider.childContextTypes = {
   store: storeShape.isRequired
 }
-
-module.exports = Provider

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -1,10 +1,10 @@
-const { Component, createElement } = require('react')
-const storeShape = require('../utils/storeShape')
-const shallowEqual = require('../utils/shallowEqual')
-const isPlainObject = require('../utils/isPlainObject')
-const wrapActionCreators = require('../utils/wrapActionCreators')
-const hoistStatics = require('hoist-non-react-statics')
-const invariant = require('invariant')
+import { Component, createElement } from 'react'
+import storeShape from '../utils/storeShape'
+import shallowEqual from '../utils/shallowEqual'
+import isPlainObject from '../utils/isPlainObject'
+import wrapActionCreators from '../utils/wrapActionCreators'
+import hoistStatics from 'hoist-non-react-statics'
+import invariant from 'invariant'
 
 const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-vars
 const defaultMapDispatchToProps = dispatch => ({ dispatch })
@@ -21,7 +21,7 @@ function getDisplayName(WrappedComponent) {
 // Helps track hot reloading.
 let nextVersion = 0
 
-function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
+export default function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
   const shouldSubscribe = Boolean(mapStateToProps)
   const finalMapStateToProps = mapStateToProps || defaultMapStateToProps
   const finalMapDispatchToProps = isPlainObject(mapDispatchToProps) ?
@@ -273,5 +273,3 @@ function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) 
     return hoistStatics(Connect, WrappedComponent)
   }
 }
-
-module.exports = connect

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const Provider = require('./components/Provider')
-const connect = require('./components/connect')
+import Provider from './components/Provider'
+import connect from './components/connect'
 
-module.exports = { Provider, connect }
+export { Provider, connect }

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -4,7 +4,7 @@ const fnToString = (fn) => Function.prototype.toString.call(fn)
  * @param {any} obj The object to inspect.
  * @returns {boolean} True if the argument appears to be a plain object.
  */
-function isPlainObject(obj) {
+export default function isPlainObject(obj) {
   if (!obj || typeof obj !== 'object') {
     return false
   }
@@ -23,5 +23,3 @@ function isPlainObject(obj) {
     && constructor instanceof constructor
     && fnToString(constructor) === fnToString(Object)
 }
-
-module.exports = isPlainObject

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,4 +1,4 @@
-function shallowEqual(objA, objB) {
+export default function shallowEqual(objA, objB) {
   if (objA === objB) {
     return true
   }
@@ -21,5 +21,3 @@ function shallowEqual(objA, objB) {
 
   return true
 }
-
-module.exports = shallowEqual

--- a/src/utils/storeShape.js
+++ b/src/utils/storeShape.js
@@ -1,9 +1,7 @@
-const { PropTypes } = require('react')
+import { PropTypes } from 'react'
 
-const storeShape = PropTypes.shape({
+export default PropTypes.shape({
   subscribe: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
   getState: PropTypes.func.isRequired
 })
-
-module.exports = storeShape

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -1,7 +1,5 @@
 import { bindActionCreators } from 'redux'
 
-function wrapActionCreators(actionCreators) {
+export default function wrapActionCreators(actionCreators) {
   return dispatch => bindActionCreators(actionCreators, dispatch)
 }
-
-module.exports = wrapActionCreators


### PR DESCRIPTION
and point to it from jsnext:main.

relatively inelegant build script as i have to basically replicate the babel-cli/dir script, but i can’t see a better solution.

fixes #243 