### PR TITLE
Update rackt reference to reactjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-All notable changes are described on the [Releases](https://github.com/rackt/react-redux/releases) page.
+All notable changes are described on the [Releases](https://github.com/reactjs/react-redux/releases) page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
-We are open to, and grateful for, any contributions made by the community.  By contributing to React Redux, you agree to abide by the [code of conduct](https://github.com/rackt/react-redux/blob/master/CODE_OF_CONDUCT.md).
+We are open to, and grateful for, any contributions made by the community.  By contributing to React Redux, you agree to abide by the [code of conduct](https://github.com/reactjs/react-redux/blob/master/CODE_OF_CONDUCT.md).
 
 ## Reporting Issues and Asking Questions
-Before opening an issue, please search the [issue tracker](https://github.com/rackt/react-redux/issues) to make sure your issue hasn't already been reported.
+Before opening an issue, please search the [issue tracker](https://github.com/reactjs/react-redux/issues) to make sure your issue hasn't already been reported.
 
 Please ask any general and implementation specific questions on [Stack Overflow with a Redux tag](http://stackoverflow.com/questions/tagged/redux?sort=votes&pageSize=50) for support.
 
 ## Development
 
-Visit the [Issue tracker](https://github.com/rackt/react-redux/issues) to find a list of open issues that need attention.
+Visit the [Issue tracker](https://github.com/reactjs/react-redux/issues) to find a list of open issues that need attention.
 
 Fork, then clone the repo:
 ```
@@ -56,11 +56,11 @@ Please open an issue with a proposal for a new feature or refactoring before sta
 
 ###Style
 
-[rackt](https://github.com/rackt) is trying to keep a standard style across its various projects, which can be found over in [eslint-config-rackt](https://github.com/rackt/eslint-config-rackt). If you have a style change proposal, it should first be proposed there. If accepted, we will be happy to accept a PR to implement it here.
+[reactjs](https://github.com/reactjs) is trying to keep a standard style across its various projects, which can be found over in [eslint-config-reactjs](https://github.com/reactjs/eslint-config-reactjs). If you have a style change proposal, it should first be proposed there. If accepted, we will be happy to accept a PR to implement it here.
 
 ## Submitting Changes
 
-* Open a new issue in the [Issue tracker](https://github.com/rackt/react-redux/issues).
+* Open a new issue in the [Issue tracker](https://github.com/reactjs/react-redux/issues).
 * Fork the repo.
 * Create a new feature branch based off the `master` branch.
 * Make sure all tests pass and there are no linting errors.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 React Redux
 =========================
 
-Official React bindings for [Redux](https://github.com/rackt/redux).  
+Official React bindings for [Redux](https://github.com/reactjs/redux).
 Performant and flexible.
 
 [![build status](https://img.shields.io/travis/reactjs/react-redux/master.svg?style=flat-square)](https://travis-ci.org/reactjs/react-redux) [![npm version](https://img.shields.io/npm/v/react-redux.svg?style=flat-square)](https://www.npmjs.com/package/react-redux)
@@ -25,7 +25,7 @@ If you don’t yet use [npm](http://npmjs.com/) or a modern module bundler, and 
 
 As of React Native 0.18, React Redux 4.x should work with React Native. If you have any issues with React Redux 4.x on React Native, run `npm ls react` and make sure you don’t have a duplicate React installation in your `node_modules`. We recommend that you use `npm@3.x` which is better at avoiding this sort of issues.
 
-If you are on an older version of React Native, you’ll need to keep using [React Redux 3.x branch and documentation](https://github.com/rackt/react-redux/tree/v3.1.0) because of [this problem](https://github.com/facebook/react-native/issues/2985).
+If you are on an older version of React Native, you’ll need to keep using [React Redux 3.x branch and documentation](https://github.com/reactjs/react-redux/tree/v3.1.0) because of [this problem](https://github.com/facebook/react-native/issues/2985).
 
 ## Documentation
 
@@ -37,7 +37,7 @@ If you are on an older version of React Native, you’ll need to keep using [Rea
 
 ## How Does It Work?
 
-We do a deep dive on how React Redux works in [this readthesource episode](https://www.youtube.com/watch?v=VJ38wSFbM3A).  
+We do a deep dive on how React Redux works in [this readthesource episode](https://www.youtube.com/watch?v=VJ38wSFbM3A).
 Enjoy!
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 React Redux
 =========================
 
-Official React bindings for [Redux](https://github.com/reactjs/redux).
+Official React bindings for [Redux](https://github.com/reactjs/redux).  
 Performant and flexible.
 
 [![build status](https://img.shields.io/travis/reactjs/react-redux/master.svg?style=flat-square)](https://travis-ci.org/reactjs/react-redux) [![npm version](https://img.shields.io/npm/v/react-redux.svg?style=flat-square)](https://www.npmjs.com/package/react-redux)
@@ -37,7 +37,7 @@ If you are on an older version of React Native, you’ll need to keep using [Rea
 
 ## How Does It Work?
 
-We do a deep dive on how React Redux works in [this readthesource episode](https://www.youtube.com/watch?v=VJ38wSFbM3A).
+We do a deep dive on how React Redux works in [this readthesource episode](https://www.youtube.com/watch?v=VJ38wSFbM3A).  
 Enjoy!
 
 ## License

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ ReactDOM.render(
 
 Connects a React component to a Redux store.
 
-It does not modify the component class passed to it.
+It does not modify the component class passed to it.  
 Instead, it *returns* a new, connected component class, for you to use.
 
 #### Arguments
@@ -108,8 +108,8 @@ export default connect()(TodoApp)
 
 ##### Inject `dispatch` and every field in the global state
 
->Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.
->It’s better to have more granular `connect()` on several components in your view hierarchy that each only
+>Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.  
+>It’s better to have more granular `connect()` on several components in your view hierarchy that each only  
 >listen to a relevant slice of the state.
 
 ```js

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ If you *really* need to, you can manually pass `store` as a prop to every `conne
 
 #### Props
 
-* `store` (*[Redux Store](http://rackt.github.io/redux/docs/api/Store.html)*): The single Redux store in your application.
+* `store` (*[Redux Store](http://redux.js.org/docs/api/Store.html)*): The single Redux store in your application.
 * `children` (*ReactElement*) The root of your component hierarchy.
 
 #### Example
@@ -53,18 +53,18 @@ ReactDOM.render(
 
 Connects a React component to a Redux store.
 
-It does not modify the component class passed to it.  
+It does not modify the component class passed to it.
 Instead, it *returns* a new, connected component class, for you to use.
 
 #### Arguments
 
 * [`mapStateToProps(state, [ownProps]): stateProps`] \(*Function*): If specified, the component will subscribe to Redux store updates. Any time it updates, `mapStateToProps` will be called. Its result must be a plain object*, and it will be merged into the component’s props. If you omit it, the component will not be subscribed to the Redux store. If `ownProps` is specified as a second argument, its value will be the props passed to your component, and `mapStateToProps` will be re-invoked whenever the component receives new props.
 
-  >Note: in advanced scenarios where you need more control over the rendering performance, `mapStateToProps()` can also return a function. In this case, *that* function will be used as `mapStateToProps()` for a particular component instance. This allows you to do per-instance memoization. You can refer to [#279](https://github.com/rackt/react-redux/pull/279) and the tests it adds for more details. Most apps never need this.
+  >Note: in advanced scenarios where you need more control over the rendering performance, `mapStateToProps()` can also return a function. In this case, *that* function will be used as `mapStateToProps()` for a particular component instance. This allows you to do per-instance memoization. You can refer to [#279](https://github.com/reactjs/react-redux/pull/279) and the tests it adds for more details. Most apps never need this.
 
-* [`mapDispatchToProps(dispatch, [ownProps]): dispatchProps`] \(*Object* or *Function*): If an object is passed, each function inside it will be assumed to be a Redux action creator. An object with the same function names, but with every action creator wrapped into a `dispatch` call so they may be invoked directly, will be merged into the component’s props. If a function is passed, it will be given `dispatch`. It’s up to you to return an object that somehow uses `dispatch` to bind action creators in your own way. (Tip: you may use the [`bindActionCreators()`](http://rackt.github.io/redux/docs/api/bindActionCreators.html) helper from Redux.) If you omit it, the default implementation just injects `dispatch` into your component’s props. If `ownProps` is specified as a second argument, its value will be the props passed to your component, and `mapDispatchToProps` will be re-invoked whenever the component receives new props.
+* [`mapDispatchToProps(dispatch, [ownProps]): dispatchProps`] \(*Object* or *Function*): If an object is passed, each function inside it will be assumed to be a Redux action creator. An object with the same function names, but with every action creator wrapped into a `dispatch` call so they may be invoked directly, will be merged into the component’s props. If a function is passed, it will be given `dispatch`. It’s up to you to return an object that somehow uses `dispatch` to bind action creators in your own way. (Tip: you may use the [`bindActionCreators()`](http://reactjs.github.io/redux/docs/api/bindActionCreators.html) helper from Redux.) If you omit it, the default implementation just injects `dispatch` into your component’s props. If `ownProps` is specified as a second argument, its value will be the props passed to your component, and `mapDispatchToProps` will be re-invoked whenever the component receives new props.
 
-  >Note: in advanced scenarios where you need more control over the rendering performance, `mapDispatchToProps()` can also return a function. In this case, *that* function will be used as `mapDispatchToProps()` for a particular component instance. This allows you to do per-instance memoization. You can refer to [#279](https://github.com/rackt/react-redux/pull/279) and the tests it adds for more details. Most apps never need this.
+  >Note: in advanced scenarios where you need more control over the rendering performance, `mapDispatchToProps()` can also return a function. In this case, *that* function will be used as `mapDispatchToProps()` for a particular component instance. This allows you to do per-instance memoization. You can refer to [#279](https://github.com/reactjs/react-redux/pull/279) and the tests it adds for more details. Most apps never need this.
 
 * [`mergeProps(stateProps, dispatchProps, ownProps): props`] \(*Function*): If specified, it is passed the result of `mapStateToProps()`, `mapDispatchToProps()`, and the parent `props`. The plain object you return from it will be passed as props to the wrapped component. You may specify this function to select a slice of the state based on props, or to bind action creators to a particular variable from props. If you omit it, `Object.assign({}, ownProps, stateProps, dispatchProps)` is used by default.
 
@@ -96,7 +96,7 @@ Returns the wrapped component instance. Only available if you pass `{ withRef: t
 
 * It does not modify the passed React component. It returns a new, connected component, that you should use instead.
 
-* The `mapStateToProps` function takes a single argument of the entire Redux store’s state and returns an object to be passed as props. It is often called a **selector**. Use [reselect](https://github.com/rackt/reselect) to efficiently compose selectors and [compute derived data](http://rackt.github.io/redux/docs/recipes/ComputingDerivedData.html).
+* The `mapStateToProps` function takes a single argument of the entire Redux store’s state and returns an object to be passed as props. It is often called a **selector**. Use [reselect](https://github.com/reactjs/reselect) to efficiently compose selectors and [compute derived data](http://redux.js.org/docs/recipes/ComputingDerivedData.html).
 
 #### Examples
 
@@ -108,8 +108,8 @@ export default connect()(TodoApp)
 
 ##### Inject `dispatch` and every field in the global state
 
->Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.  
->It’s better to have more granular `connect()` on several components in your view hierarchy that each only  
+>Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.
+>It’s better to have more granular `connect()` on several components in your view hierarchy that each only
 >listen to a relevant slice of the state.
 
 ```js

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ In short,
 
 ### My views aren’t updating on route change with React Router 0.13
 
-If you’re using React Router 0.13, you might [bump into this problem](https://github.com/rackt/react-redux/issues/43). The solution is simple: whenever you use `<RouteHandler>` or the `Handler` provided by `Router.run`, pass the router state to it.
+If you’re using React Router 0.13, you might [bump into this problem](https://github.com/reactjs/react-redux/issues/43). The solution is simple: whenever you use `<RouteHandler>` or the `Handler` provided by `Router.run`, pass the router state to it.
 
 Root view:
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gaearon/react-redux.git"
+    "url": "https://github.com/reactjs/react-redux.git"
   },
   "files": [
     "dist",

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -14,7 +14,7 @@ function warnAboutReceivingStore() {
       '<Provider> does not support changing `store` on the fly. ' +
       'It is most likely that you see this error because you updated to ' +
       'Redux 2.x and React Redux 2.x which no longer hot reload reducers ' +
-      'automatically. See https://github.com/rackt/react-redux/releases/' +
+      'automatically. See https://github.com/reactjs/react-redux/releases/' +
       'tag/v2.0.0 for the migration instructions.'
     )
   }

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -96,7 +96,7 @@ describe('React', () => {
         '<Provider> does not support changing `store` on the fly. ' +
         'It is most likely that you see this error because you updated to ' +
         'Redux 2.x and React Redux 2.x which no longer hot reload reducers ' +
-        'automatically. See https://github.com/rackt/react-redux/releases/' +
+        'automatically. See https://github.com/reactjs/react-redux/releases/' +
         'tag/v2.0.0 for the migration instructions.'
       )
 


### PR DESCRIPTION
Update rackt references to reactjs.

Addresses comments at https://github.com/reactjs/react-redux/pull/299