### PR TITLE
Use componentWillMount instead of componentDidMount for subscriptions

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -176,7 +176,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         }
       }
 
-      componentDidMount() {
+      componentWillMount() {
         this.trySubscribe()
       }
 


### PR DESCRIPTION
Even if this PR doesn't get accepted, I'm hoping to find out the reasoning behind the current implementation and find out what patterns to use to avoid the problem I found. The problem being...

Because component store subscriptions are created in `componentDidMount` (which fires child before parent), you can get into situations like this:

1. Parents make a decision about what components to render, based on store state.
2. Children get current store state which is fine.
3. Store state is changed, requiring a new component tree.
4. Children get new store state before the parents, which is bad, because the new state may not make any sense for the new components.
5. Parents get new store state and switch out components. But it's too late, because children have already received bad state.

Here's a simple example showing the problem:

https://jsfiddle.net/justindeal/myqyxpcw/6/

There's a value in the store 'a' or 'b' which is used to switch components `A` and `B`. I have some side effect rendering to show what values are actually rendered by `A` and `B`. You can see that `A` incorrectly gets a 'b' value on the first toggle.

By switching to `componentWillMount`, subscriptions are always in parent-child order, so there's never any inconsistent state.

If you want to consider a simple real-world case, think about the filter string from the canonical todo example. Now consider that you can switch between todos and recipes. The filter for todos may make no sense for filtering recipes. So sending the global filter for todos to the child recipe components makes no sense and can cause errors to be thrown if unexpected props/values show up.

This change had one side effect for existing tests: because we haven't yet rendered when subscribing, the impure case avoids a duplicate initial call to its state mapping function. As far as I can tell, this has no effect on what's actually rendered though.

I also saw no negative outcome when I made the change for my app. (Just a fix to the surprising behavior I saw.) But I'm curious to get some feedback.

Thanks!