### PR TITLE
Add example to API docs for no-subscribe actions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,14 @@ Returns the wrapped component instance. Only available if you pass `{ withRef: t
 export default connect()(TodoApp)
 ```
 
+##### Inject all action creators  (`addTodo`, `completeTodo`, ...) without subscribing to the store
+
+```js
+import * as actionCreators from './actionCreators'
+
+export default connect(null, actionCreators)(TodoApp)
+```
+
 ##### Inject `dispatch` and every field in the global state
 
 >Don’t do this! It kills any performance optimizations because `TodoApp` will rerender after every action.  
@@ -126,7 +134,7 @@ function mapStateToProps(state) {
 export default connect(mapStateToProps)(TodoApp)
 ```
 
-##### Inject `todos` and all action creators (`addTodo`, `completeTodo`, ...)
+##### Inject `todos` and all action creators
 
 ```js
 import * as actionCreators from './actionCreators'


### PR DESCRIPTION
In a recent project, I needed a container component that had access to a few actions, but it didn't need to subscribe to the store. The component was just a button that performed an action; it didn't care about what the state of the app was.

The docs for `connect` don't have an example for how to omit the `mapStateToProps` argument, while still providing a value for `mapDispatchToProps`.

I'm not entirely sure if this is the best way to accomplish that goal, so please do let me know if there's a better/simpler way! I tried simply passing a single `mapDispatchToProps` argument, but it was interpreted as the `mapStateToProps` param.