### PR TITLE
Fix #337, update impure component with custom mergeProps

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -39,8 +39,8 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     mapDispatchToProps || defaultMapDispatchToProps
 
   const finalMergeProps = mergeProps || defaultMergeProps
-  const checkMergedEquals = finalMergeProps !== defaultMergeProps
   const { pure = true, withRef = false } = options
+  const checkMergedEquals = pure && finalMergeProps !== defaultMergeProps
 
   // Helps track hot reloading.
   const version = nextVersion++

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1639,5 +1639,38 @@ describe('React', () => {
       expect(mapStateCalls).toBe(2)
       expect(renderCalls).toBe(1)
     })
+
+    it('should update impure components with custom mergeProps', () => {
+      let store = createStore(() => ({}))
+      let renderCount = 0
+
+      @connect(null, null, () => ({ a: 1 }), { pure: false })
+      class Container extends React.Component {
+        render() {
+          ++renderCount
+          return <div />
+        }
+      }
+
+      class Parent extends React.Component {
+        componentDidMount() {
+          this.forceUpdate()
+        }
+        render() {
+          return <Container />
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Parent>
+            <Container />
+          </Parent>
+        </ProviderMock>
+      )
+
+      expect(renderCount).toBe(2)
+    })
+
   })
 })


### PR DESCRIPTION
Needed to check if the component is pure to determine whether we can rely on `checkMergedEquals` behavior in setting the updated merged props. Fixes #337, test included.