### PR TITLE
Upgrade React 15 peerDependency to stable (15.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "loose-envify": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc.1",
+    "react": "^0.14.0 || ^15.0.1",
     "redux": "^2.0.0 || ^3.0.0"
   },
   "browserify": {


### PR DESCRIPTION
Current issue:

```
$ npm i --save react@15

npm ERR! peerinvalid The package react@15.0.1 does not satisfy its siblings' 
peerDependencies requirements!
npm ERR! peerinvalid Peer react-redux@4.4.1 wants react@^0.14.0 || ^15.0.0-rc.1
```