### PR TITLE
Use callback ref instead of string

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -222,7 +222,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           `{ withRef: true } as the fourth argument of the connect() call.`
         )
 
-        return this.refs.wrappedInstance
+        return this.wrappedInstanceRef
       }
 
       render() {
@@ -272,7 +272,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         if (withRef) {
           this.renderedElement = createElement(WrappedComponent, {
             ...this.mergedProps,
-            ref: 'wrappedInstance'
+            ref: (ref) => this.wrappedInstanceRef = ref
           })
         } else {
           this.renderedElement = createElement(WrappedComponent,

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1297,7 +1297,7 @@ describe('React', () => {
 
       expect(() => decorated.someInstanceMethod()).toThrow()
       expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData)
-      expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
+      expect(decorated.wrappedInstanceRef.someInstanceMethod()).toBe(someData)
     })
 
     it('should wrap impure components without supressing updates', () => {


### PR DESCRIPTION
Not sure if you care about this, but I was browsing the source code and noticed you were still using a string ref. I just updated it to a callback ref.