### PR TITLE
more test for shallowEqual

### DIFF
--- a/test/utils/shallowEqual.spec.js
+++ b/test/utils/shallowEqual.spec.js
@@ -1,5 +1,6 @@
 import expect from 'expect'
 import shallowEqual from '../../src/utils/shallowEqual'
+import _ from 'lodash'
 
 describe('Utils', () => {
   describe('shallowEqual', () => {
@@ -33,6 +34,22 @@ describe('Utils', () => {
           { a: 1, b: 2, c: o, d }
         )
       ).toBe(true)
+
+      const e = function () {return 2 }
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: o, d, e: e() },
+          { a: 1, b: 2, c: o, d, e: e() }
+        )
+      ).toBe(true)
+      const e1 = function () {return { a: 2 }}
+      const eVal = e1()
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: o, d, e: eVal },
+          { a: 1, b: 2, c: o, d, e: eVal }
+        )
+      ).toBe(true)      
     })
 
     it('should return false if arguments fields are different function identities', () => {
@@ -42,6 +59,23 @@ describe('Utils', () => {
           { a: 1, b: 2, d: function () {return 1} }
         )
       ).toBe(false)
+
+
+      const e1 = function () {return { a: 2 }}
+      expect(
+        shallowEqual(
+          { a: 1, b: 2,  e: e1() },
+          { a: 1, b: 2,  e: e1() }
+        )
+      ).toBe(false) 
+
+      const e2 = { b : { c : 2 } }
+      expect(
+        shallowEqual(
+          { a: 1, b: 2,  e: _.get(e2, 'b') },
+          { a: 1, b: 2,  e: _.get(e2, 'b') }
+        )
+      ).toBe(true) 
     })
 
     it('should return false if first argument has too many keys', () => {


### PR DESCRIPTION
Hey @gaearon ,
Something I don't understand.
Why the function `e1` and `_.get` are treated differently? Is it also due to different identity of function, or something else?