### PR TITLE
Refactor assigment of `mapDispatch` in connect.js

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -3,7 +3,6 @@ import storeShape from '../utils/storeShape'
 import shallowEqual from '../utils/shallowEqual'
 import wrapActionCreators from '../utils/wrapActionCreators'
 import warning from '../utils/warning'
-import isFunction from 'lodash/isFunction'
 import isPlainObject from 'lodash/isPlainObject'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
@@ -22,7 +21,7 @@ function getDisplayName(WrappedComponent) {
 
 function getMapDispatch(value) {
   switch (true) {
-    case isFunction(value): return value
+    case (typeof value === 'function'): return value
     case isPlainObject(value): return wrapActionCreators(value)
     default: return defaultMapDispatchToProps
   }

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -3,6 +3,7 @@ import storeShape from '../utils/storeShape'
 import shallowEqual from '../utils/shallowEqual'
 import wrapActionCreators from '../utils/wrapActionCreators'
 import warning from '../utils/warning'
+import isFunction from 'lodash/isFunction'
 import isPlainObject from 'lodash/isPlainObject'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
@@ -17,6 +18,14 @@ const defaultMergeProps = (stateProps, dispatchProps, parentProps) => ({
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+function getMapDispatch(value) {
+  switch (true) {
+    case isFunction(value): return value
+    case isPlainObject(value): return wrapActionCreators(value)
+    default: return defaultMapDispatchToProps
+  }
 }
 
 let errorObject = { value: null }
@@ -35,15 +44,7 @@ let nextVersion = 0
 export default function connect(mapStateToProps, mapDispatchToProps, mergeProps, options = {}) {
   const shouldSubscribe = Boolean(mapStateToProps)
   const mapState = mapStateToProps || defaultMapStateToProps
-
-  let mapDispatch
-  if (typeof mapDispatchToProps === 'function') {
-    mapDispatch = mapDispatchToProps
-  } else if (!mapDispatchToProps) {
-    mapDispatch = defaultMapDispatchToProps
-  } else {
-    mapDispatch = wrapActionCreators(mapDispatchToProps)
-  }
+  const mapDispatch = getMapDispatch(mapDispatchToProps)
 
   const finalMergeProps = mergeProps || defaultMergeProps
   const { pure = true, withRef = false } = options


### PR DESCRIPTION
Hey so a number of us from the [ReactVegas](http://www.meetup.com/ReactVegas/events/230293695/) meetup spent some time talking about the codebase. We specifically talked about the `connect` function and the small piece of code that was doing the assignment of `mapDispatch`. In the end we went over a few ways of refactoring the code and decided that it may serve us well to submit a PR.

Here's where that input got us:
* The multiple assignments have been refactored to a single assignment and function call.
* The new function handles returning a function or an object or `defaultMapDispatchToProps`.
* The new function uses helpers from lodash to clean up type comparisons.
* The new function uses a switch statement at the moment, this seem to read well and I can provide more context on that decision. A valid alternative would be to use guard statements instead. :smile:

Overall we're excited to participate in the development of React-Redux, so any feedback is welcomed and appreciated. Thanks! :tada: 