### PR TITLE
add flow type definition file

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,19 @@
+[ignore]
+<PROJECT_ROOT>/node_modules/fbjs/.*
+
+[include]
+
+[libs]
+
+[options]
+module.use_strict=true
+munge_underscores=true
+suppress_comment= \\(.\\|\n\\)*\\$FlowDisableLine
+suppress_comment= \\(.\\|\n\\)*\\$FlowBug
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable
+esproposal.decorators=ignore
+traces=3
+
+[version]
+>=0.25.0

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 npm-debug.log
 .DS_Store
 dist
-lib
+lib/*
+!lib/index.js.flow
 coverage

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -2,12 +2,14 @@
 type ConnectAll = <D, P, S, C: React$Component<D, P, S>, SP, DP, Dispatch: Function>(
   mapStateToProps: (state: Object) => SP,
   mapDispatchToProps: (dispatch: Dispatch) => DP,
+  mergeProps: null | void,
   options?: {pure?: boolean, withRef?: boolean}
 ) => (component: Class<C>) => Class<React$Component<D, $Diff<$Diff<P, DP>, SP>, S>>
 
 type ConnectAllStateless = <P, SP, DP, Dispatch: Function>(
   mapStateToProps: (state: Object) => SP,
   mapDispatchToProps: (dispatch: Dispatch) => DP,
+  mergeProps: null | void,
   options?: {pure?: boolean, withRef?: boolean}
 ) => (component: (props: P) => any) => Class<React$Component<void, $Diff<$Diff<P, DP>, SP>, void>>
 
@@ -28,22 +30,28 @@ type ConnectMergedStateless = <P, SP, DP, MP, Dispatch: Function>(
 type ConnectNoState = <D, P, S, C: React$Component<D, P, S>, DP, Dispatch: Function>(
     mapStateToProps: null | void,
     mapDispatchToProps: (dispatch: Dispatch) => DP,
+    mergeProps: null | void,
     options?: {pure?: boolean, withRef?: boolean}
   ) => (component: Class<C>) => Class<React$Component<D, $Diff<P, DP>, S>>
 
 type ConnectNoStateStatless = <P, DP, Dispatch: Function>(
     mapStateToProps: null | void,
     mapDispatchToProps: (dispatch: Dispatch) => DP,
+    mergeProps: null | void,
     options?: {pure?: boolean, withRef?: boolean}
   ) => (component: (props: P) => any) => Class<React$Component<void, $Diff<P, DP>, void>>
 
-type ConnectDisptch = <D, P, S, C: React$Component<D, P, S>, SP, Dispatch: Function>(
+type ConnectDispatch = <D, P, S, C: React$Component<D, P, S>, SP, Dispatch: Function>(
   mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: null | void,
+  mergeProps: null | void,
   options?: {pure?: boolean, withRef?: boolean}
 ) => (component: Class<C>) => Class<React$Component<D, $Diff<$Diff<P, {dispatch: Dispatch}>, SP>, S>>
 
-type ConnectDisptchStateless = <P, SP, Dispatch: Function>(
+type ConnectDispatchStateless = <P, SP, Dispatch: Function>(
   mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: null | void,
+  mergeProps: null | void,
   options?: {pure?: boolean, withRef?: boolean}
 ) => (component: (props: P) => any) => Class<React$Component<void, $Diff<$Diff<P, {dispatch: Dispatch}>, SP>, void>>
 
@@ -60,8 +68,8 @@ declare export var connect
     & ConnectMergedStateless
     & ConnectNoState
     & ConnectNoStateStatless
-    & ConnectDisptch
-    & ConnectDisptchStateless
+    & ConnectDispatch
+    & ConnectDispatchStateless
     & ConnectDefault
     & ConnectDefaultStateless;
 declare export var Provider: ReactClass<{store: Object, children?: any}>;

--- a/lib/index.js.flow
+++ b/lib/index.js.flow
@@ -1,0 +1,69 @@
+/* @flow */
+type ConnectAll = <D, P, S, C: React$Component<D, P, S>, SP, DP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: (dispatch: Dispatch) => DP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: Class<C>) => Class<React$Component<D, $Diff<$Diff<P, DP>, SP>, S>>
+
+type ConnectAllStateless = <P, SP, DP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: (dispatch: Dispatch) => DP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: (props: P) => any) => Class<React$Component<void, $Diff<$Diff<P, DP>, SP>, void>>
+
+type ConnectMerged = <D, P, S, C: React$Component<D, P, S>, SP, DP, MP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: (dispatch: Dispatch) => DP,
+  mergeProps: (stateProps: SP, dispatchProps: DP, origProps: P) => MP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: Class<C>) => Class<React$Component<D, $Diff<P, MP>, S>>
+
+type ConnectMergedStateless = <P, SP, DP, MP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  mapDispatchToProps: (dispatch: Dispatch) => DP,
+  mergeProps: (stateProps: SP, dispatchProps: DP, origProps: P) => MP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: (props: P) => any) => Class<React$Component<void, $Diff<P, MP>, void>>
+
+type ConnectNoState = <D, P, S, C: React$Component<D, P, S>, DP, Dispatch: Function>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: (dispatch: Dispatch) => DP,
+    options?: {pure?: boolean, withRef?: boolean}
+  ) => (component: Class<C>) => Class<React$Component<D, $Diff<P, DP>, S>>
+
+type ConnectNoStateStatless = <P, DP, Dispatch: Function>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: (dispatch: Dispatch) => DP,
+    options?: {pure?: boolean, withRef?: boolean}
+  ) => (component: (props: P) => any) => Class<React$Component<void, $Diff<P, DP>, void>>
+
+type ConnectDisptch = <D, P, S, C: React$Component<D, P, S>, SP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: Class<C>) => Class<React$Component<D, $Diff<$Diff<P, {dispatch: Dispatch}>, SP>, S>>
+
+type ConnectDisptchStateless = <P, SP, Dispatch: Function>(
+  mapStateToProps: (state: Object) => SP,
+  options?: {pure?: boolean, withRef?: boolean}
+) => (component: (props: P) => any) => Class<React$Component<void, $Diff<$Diff<P, {dispatch: Dispatch}>, SP>, void>>
+
+type ConnectDefault = <D, P, S, C: React$Component<D, P, S>, Dispatch: Function>() =>
+  (component: Class<C>) => Class<React$Component<D, $Diff<P, {dispatch: Dispatch}>, S>>
+
+type ConnectDefaultStateless = () =>
+  <P>(component: (props: P) => any) => Class<React$Component<void, $Diff<P, {dispatch: Function}>, void>>
+
+declare export var connect
+    : ConnectAll
+    & ConnectAllStateless
+    & ConnectMerged
+    & ConnectMergedStateless
+    & ConnectNoState
+    & ConnectNoStateStatless
+    & ConnectDisptch
+    & ConnectDisptchStateless
+    & ConnectDefault
+    & ConnectDefaultStateless;
+declare export var Provider: ReactClass<{store: Object, children?: any}>;
+
+export {connect, Provider}


### PR DESCRIPTION
This adds a flow type declaration file so that anyone using it from NPM should just get the types 'for free'

It assumes the latest version of flow (0.25, though 0.24 should work too), and adds mostly adequate type definitions for both `connect` and `Provider`. Obviously most of the code is there to type `connect` which can get pretty tricky.

Known Issues: Flow correctly doesn't support stateless React components. The type definition for connect doesn't change that fact. (I tried to do a trick to make such that any stateless function component decorated with `connect` would just start getting type checked, but that didn't quite work in practice.)
