### PR TITLE
Update updateStatePropsIfNeeded()

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -162,7 +162,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
 
       updateStatePropsIfNeeded() {
         const nextStateProps = this.computeStateProps(this.store, this.props)
-        if (this.stateProps && shallowEqual(nextStateProps, this.stateProps)) {
+        if (pure && this.stateProps && shallowEqual(nextStateProps, this.stateProps)) {
           return false
         }
 


### PR DESCRIPTION
If component not pure (options {pure: false}), I think, that we don't need shallow compare states in updateStatePropsIfNeeded() and need always return true.
