### PR TITLE
[skip ci] Tiny document fix: `args` is not used

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -100,8 +100,8 @@ function mapStateToProps() {
 ```
 ```javascript
 const mapStateToProps = (...args) => {
-  console.log(arguments[0]); // state
-  console.log(arguments[1]); // ownProps
+  console.log(args[0]); // state
+  console.log(args[1]); // ownProps
 }
 ```
 


### PR DESCRIPTION
I found a typo in variadic arguments example for `mapStateToProps`.  `args` is not used.