### PR TITLE
Throw if no component is passed to connect

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -53,6 +53,11 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
   const version = nextVersion++
 
   return function wrapWithConnect(WrappedComponent) {
+    invariant(
+      typeof WrappedComponent == 'function',
+      `You must pass a component to the function returned by ` +
+      `connect. Instead received ${WrappedComponent}`
+    )
     const connectDisplayName = `Connect(${getDisplayName(WrappedComponent)})`
 
     function checkStateShape(props, methodName) {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1017,6 +1017,12 @@ describe('React', () => {
       expect(stub.props.passVal).toBe('otherval')
     })
 
+    it('should throw an error if a component is not passed to the function returned by connect', () => {
+      expect(connect()).toThrow(
+        /You must pass a component to the function/
+      )
+    })
+
     it('should throw an error if mapState, mapDispatch, or mergeProps returns anything but a plain object', () => {
       const store = createStore(() => ({}))
 


### PR DESCRIPTION
Currently, if you fail to pass a component to the function returned by `connect` it fails in a confusing way (usually `inst.render is not a function`) that can be hard to track down if you're new to Redux.

This PR adds a check, making sure a function is passed to `connect`, throwing a useful error if not.
