### PR TITLE
Proposal for standardising getWrappedInstance methods on wrappers

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -267,11 +267,15 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           `To access the wrapped instance, you need to specify ` +
           `{ withRef: true } as the fourth argument of the connect() call.`
         )
-        let wrappedInstance = this.refs.wrappedInstance;
-				if (unwraps > 1) {
-          wrappedInstance = wrappedInstance.getWrappedInstance(unwraps - 1);
+        let wrappedInstance = this.refs.wrappedInstance
+        if (unwraps > 1) {
+          invariant(typeof wrappedInstance.getWrappedInstance !== 'function',
+            `Wrapped Instance did not have a getWrappedInstance method ` +
+            `to continuing unwrapping at level ${unwraps}`
+          )
+          wrappedInstance = wrappedInstance.getWrappedInstance(unwraps - 1)
         }
-				return wrappedInstance;
+        return wrappedInstance
       }
 
       render() {

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -262,13 +262,16 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         this.setState({ storeState })
       }
 
-      getWrappedInstance() {
+      getWrappedInstance(unwraps = 1) {
         invariant(withRef,
           `To access the wrapped instance, you need to specify ` +
           `{ withRef: true } as the fourth argument of the connect() call.`
         )
-
-        return this.refs.wrappedInstance
+        let wrappedInstance = this.refs.wrappedInstance;
+				if (unwraps > 1) {
+          wrappedInstance = wrappedInstance.getWrappedInstance(unwraps - 1);
+        }
+				return wrappedInstance;
       }
 
       render() {


### PR DESCRIPTION
I've come into this issue once or twice now, primarily as a result of the amount of component wrappers a given React component can accumulate. Right now I have some with ```connect``` (react-redux), ```injectIntl``` (react-intl) and ```withStyles``` (isomorphic-style-loader) all at once.

So if you have a component that is wrapped three times, and you want to get to the last wrapped instance, you need to do ```this.refs.component.getWrappedInstance().getWrappedInstance().getWrappedInstance()```...

It would be nice for there to be a standard for how you might access wrapped instances where there are multiple levels at play. This concept proposes something like ```this.refs.yourComponent.getWrappedInstance(3)``` to do that. I also like the idea of having a means to go all the way down to the last component without necessarily having to specify the amount of layers to unwrap. Just an idea.

I'm posting this here as I think this library has the popularity to set a good standard with how this might be done, which others could follow.

Let me know thoughts :)