### PR TITLE
bind proper store context in connectAdvanced and the Subscription util

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -159,7 +159,8 @@ export default function connectAdvanced(
       }
 
       initSelector() {
-        const { dispatch, getState } = this.store
+        const { dispatch } = this.store
+        let getState = this.store.getState.bind(this.store)
         const sourceSelector = selectorFactory(dispatch, selectorFactoryOptions)
 
         // wrap the selector in an object that tracks its results between runs

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -106,6 +106,10 @@ export default function connectAdvanced(
           `or explicitly pass "${storeKey}" as a prop to "${displayName}".`
         )
 
+        // make sure `getState` is properly bound in order to avoid breaking
+        // custom store implementations that rely on the store's context
+        this.getState = this.store.getState.bind(this.store);
+
         this.initSelector()
         this.initSubscription()
       }
@@ -160,7 +164,7 @@ export default function connectAdvanced(
 
       initSelector() {
         const { dispatch } = this.store
-        let getState = this.store.getState.bind(this.store)
+        const { getState } = this;
         const sourceSelector = selectorFactory(dispatch, selectorFactoryOptions)
 
         // wrap the selector in an object that tracks its results between runs

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -5,7 +5,7 @@ export default class Subscription {
   constructor(store, parentSub) {
     this.subscribe = parentSub
       ? parentSub.addNestedSub.bind(parentSub)
-      : store.subscribe
+      : store.subscribe.bind(store)
 
     this.unsubscribe = null
     this.nextListeners = this.currentListeners = []


### PR DESCRIPTION
Addresses https://github.com/reactjs/react-redux/issues/464.

The issue explains this fix pretty well, but basically in the previous version of `connect` the store's context was respected when calling `getState` or `subscribe`. I move that we should have that be respected in this version as well.

Also left you a quick video:

https://www.opentest.co/share/2093c4a0652111e6a1ffdd04f7a207b4