### PR TITLE
Enable actions via context for dependency injection

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -146,9 +146,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
       }
 
       configureFinalMapDispatch(store, props, actions) {
-
         const mappedDispatch = mapDispatch(store.dispatch, props, actions)
-
         const isFactory = typeof mappedDispatch === 'function'
 
         this.finalMapDispatchToProps = isFactory ? mappedDispatch : mapDispatch

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -82,7 +82,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         super(props, context)
         this.version = version
         this.store = props.store || context.store
-        this.actions = context.actions;
+        this.actions = context.actions
 
         invariant(this.store,
           `Could not find "store" in either the context or ` +

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -6,7 +6,6 @@ import warning from '../utils/warning'
 import isPlainObject from 'lodash/isPlainObject'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
-import { bindActionCreators } from 'redux'
 import { PropTypes } from 'react'
 
 const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-vars

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -1,5 +1,12 @@
 import { bindActionCreators } from 'redux'
 
 export default function wrapActionCreators(actionCreators) {
-  return dispatch => bindActionCreators(actionCreators, dispatch)
+  return (dispatch, props, actions) => {
+    for (let key in actionCreators) {
+      if (typeof actionCreators[key] === 'string' && typeof actions[actionCreators[key]] === 'function') {
+        actionCreators[key] = actions[actionCreators[key]];
+      }
+    }
+    return bindActionCreators(actionCreators, dispatch)
+  }
 }

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux'
 export default function wrapActionCreators(actionCreators) {
   return (dispatch, props, actions) => {
     for (let key in actionCreators) {
-      if (typeof actionCreators[key] === 'string' && typeof actions[actionCreators[key]] === 'function') {
+      if (typeof actionCreators[key] === 'string' && actions && typeof actions[actionCreators[key]] === 'function') {
         actionCreators[key] = actions[actionCreators[key]];
       }
     }

--- a/src/utils/wrapActionCreators.js
+++ b/src/utils/wrapActionCreators.js
@@ -4,7 +4,7 @@ export default function wrapActionCreators(actionCreators) {
   return (dispatch, props, actions) => {
     for (let key in actionCreators) {
       if (typeof actionCreators[key] === 'string' && actions && typeof actions[actionCreators[key]] === 'function') {
-        actionCreators[key] = actions[actionCreators[key]];
+        actionCreators[key] = actions[actionCreators[key]]
       }
     }
     return bindActionCreators(actionCreators, dispatch)


### PR DESCRIPTION
This PR is to enable actions via context to make writing unit tests for containers easier using dependency injection.
- Explanation of the problem: http://alexlobera.com/react-dependency-injection-write-easier-unit-tests/
- Example using this PR: https://github.com/alexlbr/redix/tree/master/examples/react-redux-context-actions