### PR TITLE
Allow merge function to return a factory

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -65,7 +65,14 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     }
 
     function computeMergedProps(stateProps, dispatchProps, parentProps) {
-      const mergedProps = finalMergeProps(stateProps, dispatchProps, parentProps)
+      let mergedProps = finalMergeProps(stateProps, dispatchProps, parentProps)
+      
+      const isFactory = typeof mergedProps === 'function'
+      
+      if (isFactory) {
+        mergedProps = mergedProps(stateProps, dispatchProps, parentProps)
+      }
+
       if (process.env.NODE_ENV !== 'production') {
         checkStateShape(mergedProps, 'mergeProps')
       }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -429,6 +429,37 @@ describe('React', () => {
       expect(stub.props.stateThing).toBe('HELLO azbzcZ')
     })
 
+    it('should allow providing a factory function to mergeProps', () => {
+      const store = createStore(() => ({
+        a: 123
+      }))
+      
+      function sum(a, b) {
+        return a + b
+      }
+
+      @connect(
+        state => state,
+        () => ({ sum }),
+        () => (stateProps, dispatchProps, parentProps) => ({
+          sum: () => dispatchProps.sum(stateProps.a, parentProps.b)
+        })
+      )
+      class Container extends Component {
+        render() {
+          return <Passthrough result={this.props.sum()} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container b={ 456 } />
+        </ProviderMock>
+      )
+      const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
+      expect(stub.props.result).toEqual(579)
+    })
+
     it('should merge actionProps into WrappedComponent', () => {
       const store = createStore(() => ({
         foo: 'bar'


### PR DESCRIPTION
Hi. This small change allows doing the following:
```javascript
@connect(
  ({ currentProject }) => ({ currentProject }),
  {  saveSettings },
  () => {
    // createSelector from Reselect
    const saveSettingsFactory = createSelector(
      (_, dispatchProps) => dispatchProps.saveSettings,
      stateProps => stateProps.currentProject,
      (_, __, ownProps) => ownProps.appName,
      (saveSettings, project, appName) => {
        return settings => saveSettings(project, appName, settings)
      }
    )

    return (stateProps, dispatchProps, ownProps) => ({
      ...parentProps,
      ...dispatchProps,
      ...stateProps,
      saveSettings: saveSettingsFactory(stateProps, dispatchProps, ownProps)
    })
  }
)
class SettingsView extends React.Component {
  doSave(settings) {
    this.props.saveSettings(settings)
  }

  // ...
}
```

AKA Partial application. 

It helps to reduce the number of arguments component have to pass to the action.