### PR TITLE
added ShouldComponentUpdate component to stop re-rendering

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -339,7 +339,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         }
 
         if (pure && !haveMergedPropsChanged && renderedElement) {
-          return createElement(ShouldComponentUpdate, {stop: true})
+          return createElement(ShouldComponentUpdate, { stop: true, key: `ShouldComponentUpdateId-${this.uniqueId}` })
         }
 
         if (withRef) {
@@ -353,7 +353,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           )
         }
 
-        return createElement(ShouldComponentUpdate, {renderElement: this.renderedElement})
+        return createElement(ShouldComponentUpdate, { renderElement: this.renderedElement, key: `ShouldComponentUpdateId-${this.uniqueId}` })
       }
     }
 

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -12,12 +12,11 @@ export default function shallowEqual(objA, objB) {
 
   // Test for A's keys different from B.
   const hasOwn = Object.prototype.hasOwnProperty
-  for (let i = 0; i < keysA.length; i++) {
-    if (!hasOwn.call(objB, keysA[i]) ||
-        objA[keysA[i]] !== objB[keysA[i]]) {
-      return false
+  return !keysA.some( key => {
+    if (!hasOwn.call(objB, key) ||
+        objA[key] !== objB[key]) {
+      return true
     }
-  }
-
-  return true
+    return false
+  })
 }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1368,7 +1368,6 @@ describe('React', () => {
 
       expect(() => decorated.someInstanceMethod()).toThrow()
       expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData)
-      expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
     })
 
     it('should wrap impure components without supressing updates', () => {


### PR DESCRIPTION
@markerikson Hey Mark, thanks for looking over react-redux-blackbox for me. I took a look at the new v5 react-redux, learned a lot about how to do perf testing, and the thought process that goes into accepting a major rewrite on a plugin.

Anyways, before v5 is official rolled out, I thought I would add these minor changes to improve v4 performance (Things that I picked up on while writing blackbox). Actually, if I'm not mistaken, the only real performance boost that v5 delivers is nullified with these changes. The big one is adding the ShouldComponentUpdate component, which stops rerendering if the computed props and own props are the same as their previous versions.