### PR TITLE
WARN on duplicate prop

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -9,11 +9,24 @@ import invariant from 'invariant'
 
 const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-vars
 const defaultMapDispatchToProps = dispatch => ({ dispatch })
-const defaultMergeProps = (stateProps, dispatchProps, parentProps) => ({
-  ...parentProps,
-  ...stateProps,
-  ...dispatchProps
-})
+const defaultMergeProps = (stateProps, dispatchProps, parentProps) => {
+  if (process.env.NODE_ENV !== 'production') {
+    const stateKeys = Object.keys(stateProps);
+
+    for ( let key of stateKeys ) {
+      if (!!parentProps[key]) {
+        console.error(`Duplicate key ${key} sent from both parent and state`);
+        break;
+      }
+    }
+  }
+  
+  return {
+    ...parentProps,
+    ...stateProps,
+    ...dispatchProps
+  };
+}
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -11,12 +11,12 @@ const defaultMapStateToProps = state => ({}) // eslint-disable-line no-unused-va
 const defaultMapDispatchToProps = dispatch => ({ dispatch })
 const defaultMergeProps = (stateProps, dispatchProps, parentProps) => {
   if (process.env.NODE_ENV !== 'production') {
-    const stateKeys = Object.keys(stateProps);
+    const stateKeys = Object.keys(stateProps)
 
     for ( let key of stateKeys ) {
-      if (!!parentProps[key]) {
-        console.error(`Duplicate key ${key} sent from both parent and state`);
-        break;
+      if (Boolean(parentProps[key])) {
+        warning(false, `Duplicate key ${key} sent from both parent and state`)
+        break
       }
     }
   }
@@ -25,7 +25,7 @@ const defaultMergeProps = (stateProps, dispatchProps, parentProps) => {
     ...parentProps,
     ...stateProps,
     ...dispatchProps
-  };
+  }
 }
 
 function getDisplayName(WrappedComponent) {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -84,7 +84,7 @@ describe('React', () => {
 
     it('should warn if same key is used in state and props', () => {
       const store = createStore(() => ({
-        abc: 'bar',
+        abc: 'bar'
       }))
 
       @connect(({ abc }) => ({ abc }))
@@ -94,16 +94,15 @@ describe('React', () => {
         }
       }
 
-      const errorSpy = expect.spyOn(console, 'error');
+      const errorSpy = expect.spyOn(console, 'error')
 
-      const container = TestUtils.renderIntoDocument(
+      TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container abc="buz" />
         </ProviderMock>
       )
-      errorSpy.destroy();
-
-      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.destroy()
+      expect(errorSpy).toHaveBeenCalled()
     })
 
 
@@ -140,7 +139,7 @@ describe('React', () => {
         return <Passthrough {...props}/>
       })
 
-      const spy = expect.spyOn(console, 'error');
+      const spy = expect.spyOn(console, 'error')
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container />

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -82,6 +82,31 @@ describe('React', () => {
       ).toNotThrow()
     })
 
+    it('should warn if same key is used in state and props', () => {
+      const store = createStore(() => ({
+        abc: 'bar',
+      }))
+
+      @connect(({ abc }) => ({ abc }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const errorSpy = expect.spyOn(console, 'error');
+
+      const container = TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <Container abc="buz" />
+        </ProviderMock>
+      )
+      errorSpy.destroy();
+
+      expect(errorSpy).toHaveBeenCalled();
+    })
+
+
     it('should subscribe class components to the store changes', () => {
       const store = createStore(stringBuilder)
 
@@ -115,7 +140,7 @@ describe('React', () => {
         return <Passthrough {...props}/>
       })
 
-      const spy = expect.spyOn(console, 'error')
+      const spy = expect.spyOn(console, 'error');
       const tree = TestUtils.renderIntoDocument(
         <ProviderMock store={store}>
           <Container />


### PR DESCRIPTION
Fixes #499 - Add a warning to console when same key is used in both parent and state props