### PR TITLE
Set displayName explicitly on Provider

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -51,3 +51,4 @@ Provider.propTypes = {
 Provider.childContextTypes = {
   store: storeShape.isRequired
 }
+Provider.displayName = 'Provider'


### PR DESCRIPTION
When code gets uglified for production builds, original names of identifiers gets lots and React components show up with their uglified name. To remedy this, `displayName` can be set explicitly.

For `React.createClass` style components, displayName gets automatically set by babel.
React components declared using ES6-classes however, have mangled names. This is the case for `Provider`. With this PR, the name is explicitly set which should make the name survive the uglification process.  