### PR TITLE
Revert "warn on duplicate props"

### DIFF
--- a/src/connect/mergeProps.js
+++ b/src/connect/mergeProps.js
@@ -1,23 +1,7 @@
 import verifyPlainObject from '../utils/verifyPlainObject'
-import warning from '../utils/warning'
 
 export function defaultMergeProps(stateProps, dispatchProps, ownProps) {
-  if (process.env.NODE_ENV !== 'production') {
-    const stateKeys = Object.keys(stateProps)
-
-    for ( let key of stateKeys ) {
-      if (typeof ownProps[key] !== 'undefined') {
-        warning(false, `Duplicate key ${key} sent from both parent and state`)
-        break
-      }
-    }
-  }
-
-  return {
-    ...ownProps,
-    ...stateProps,
-    ...dispatchProps
-  }
+  return { ...ownProps, ...stateProps, ...dispatchProps }
 }
 
 export function wrapMergePropsFunc(mergeProps) {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -79,32 +79,6 @@ describe('React', () => {
       expect(container.context.store).toBe(store)
     })
 
-
-    it('should warn if same key is used in state and props', () => {
-      const store = createStore(() => ({
-        abc: 'bar'
-      }))
-
-      @connect(({ abc }) => ({ abc }))
-      class Container extends Component {
-        render() {
-          return <Passthrough {...this.props} />
-        }
-      }
-
-      const errorSpy = expect.spyOn(console, 'error')
-
-      TestUtils.renderIntoDocument(
-        <ProviderMock store={store}>
-        <Container abc="buz" />
-        </ProviderMock>
-      )
-      errorSpy.destroy()
-      expect(errorSpy).toHaveBeenCalled()
-    })
-
-
-
     it('should pass state and props to the given component', () => {
       const store = createStore(() => ({
         foo: 'bar',


### PR DESCRIPTION
Reverts reactjs/react-redux#508. 

The warning() call is incorrect. Also, the messaging is confusing and the backtrace is not very helpful. The DX this is supposed to improve actually detracts from it somewhat IMHO. We can try this again later.