### PR TITLE
Fix error from clear() called during notify()

### DIFF
--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -17,9 +17,9 @@ function createListenerCollection() {
     },
 
     notify() {
-      current = next
-      for (let i = 0; i < current.length; i++) {
-        current[i]()
+      const listeners = current = next
+      for (let i = 0; i < listeners.length; i++) {
+        listeners[i]()
       }
     },
 


### PR DESCRIPTION
The `current` variable would be set to `null` when `clear()` was called, which would cause an exception if there was more than one listener.

Since this pattern was modeled off of `createStore()` in `redux`, you can see it does the same thing as this [here](https://github.com/reactjs/redux/blob/master/src/createStore.js#L175-L179).