### PR TITLE
Ensure context of dispatch

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -132,7 +132,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
           return this.configureFinalMapDispatch(store, props)
         }
 
-        const { dispatch } = store
+        const dispatch = store.dispatch.bind(store)
         const dispatchProps = this.doDispatchPropsDependOnOwnProps ?
           this.finalMapDispatchToProps(dispatch, props) :
           this.finalMapDispatchToProps(dispatch)
@@ -144,7 +144,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
       }
 
       configureFinalMapDispatch(store, props) {
-        const mappedDispatch = mapDispatch(store.dispatch, props)
+        const mappedDispatch = mapDispatch(store.dispatch.bind(store), props)
         const isFactory = typeof mappedDispatch === 'function'
 
         this.finalMapDispatchToProps = isFactory ? mappedDispatch : mapDispatch


### PR DESCRIPTION
I am trying to [port](https://github.com/kevinresol/stateful/tree/rework) Redux into the [Haxe language](haxe.org) with the same compatible API. But due to the difference in the internal structure there are some context error when the port is used with react-redux. And this patch fixes that.

This patch shouldn't affect existing react-redux user, because the original Redux implemented `dispatch` as a closure over the internal `state` object and doesn't reference `this` at all. But please feel free to close if it is deemed not necessary. Thanks.
