### PR TITLE
Add typings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,6 @@ npm run lint
 
 Please open an issue with a proposal for a new feature or refactoring before starting on the work. We don't want you to waste your efforts on a pull request that we won't want to accept.
 
-###Style
-
-[reactjs](https://github.com/reactjs) is trying to keep a standard style across its various projects, which can be found over in [eslint-config-reactjs](https://github.com/reactjs/eslint-config-reactjs). If you have a style change proposal, it should first be proposed there. If accepted, we will be happy to accept a PR to implement it here.
-
 ## Submitting Changes
 
 * Open a new issue in the [Issue tracker](https://github.com/reactjs/react-redux/issues).

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentClass, Component, StatelessComponent, ReactNode } from 'react'
 import { Store, Dispatch, ActionCreator } from 'redux';
 
 interface ComponentDecorator<TOriginalProps, TOwnProps> {
-  (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps>;
+  (component: StatelessComponent<TOriginalProps>|ComponentClass<TOriginalProps>): ComponentClass<TOwnProps>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,8 +63,7 @@ interface Options {
  * generic parameter in Store here by using any as the type
  */
 export interface ProviderProps {
-  store?: Store<any>;
-  children?: ReactNode;
+  store: Store<any>;
 }
 
 export class Provider extends Component<ProviderProps, {}> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,22 +16,22 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
 export function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> }, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps>(
-  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
+  mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
 ): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> }, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
-  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps
+  mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 export function connect<State, TOwnProps, TDispatchProps>(
   mapStateToProps: null,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>
 ): ComponentDecorator<TDispatchProps, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps, TMergeProps>(
-  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps,
+  mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>,
   mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps>,
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
@@ -52,6 +52,8 @@ interface Options {
   pure?: boolean;
   withRef?: boolean;
 }
+
+type FuncOrSelf<T> = T | (() => T);
 
 /**
  * Typescript does not support generic components in tsx yet in an intuïtive way which is the reason we avoid a

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,20 +21,24 @@ export function connect<State, TOwnProps, TStateProps>(
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
   mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
-  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 export function connect<State, TOwnProps, TDispatchProps>(
   mapStateToProps: null,
-  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>
 ): ComponentDecorator<TDispatchProps, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps, TMergeProps>(
   mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
-  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps>,
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>,
   mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps>,
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+
+interface MapDispatchToPropsObject {
+  [name: string]: ActionCreator<any>;
+}
 
 interface MapStateToProps<State, TOwnProps, TStateProps> {
   (state: State, ownProps: TOwnProps): TStateProps;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,66 @@
+import { ComponentClass, Component, StatelessComponent, ReactNode } from 'react';
+import { Store, Dispatch, ActionCreator } from 'redux';
+
+interface ComponentDecorator<TOriginalProps, TOwnProps> {
+  (component: ComponentClass<TOriginalProps>|StatelessComponent<TOriginalProps>): ComponentClass<TOwnProps>;
+}
+
+/**
+ * Following 3 functions cover all possible ways connect could be invoked
+ *
+ * - State: Redux state interface (the same one used by Store<S>)
+ * - TStateProps: Result of MapStateToProps
+ * - TDispatchProps: Result of MapDispatchToProps
+ * - TOwnProps: Props passed to the wrapping component
+ */
+export function connect<TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<any> }, TOwnProps>;
+
+export function connect<State, TStateProps, TDispatchProps, TOwnProps>(
+  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
+  mapDispatchToProps?: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject
+): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+
+export function connect<State, TStateProps, TDispatchProps, TOwnProps>(
+  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
+  mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
+  options?: Options
+): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+
+interface MapStateToProps<State, TStateProps, TOwnProps> {
+  (state: State, ownProps?: TOwnProps): TStateProps;
+}
+
+/**
+ * State is not actually used here but included for consistency with Redux typings and MapStateToProps.
+ */
+interface MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps> {
+  (dispatch: Dispatch<State>, ownProps?: TOwnProps): TDispatchProps;
+}
+
+/**
+ * Any since not every ActionCreator returns the same Action
+ */
+interface MapDispatchToPropsObject {
+  [name: string]: ActionCreator<any>;
+}
+
+interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {
+  (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TStateProps & TDispatchProps;
+}
+
+interface Options {
+  pure?: boolean;
+  withRef?: boolean;
+}
+
+/**
+ * Typescript does not support generic components in tsx yet in an intuïtive way which is the reason we avoid a
+ * generic parameter in Store here by using any as the type
+ */
+export interface ProviderProps {
+  store?: Store<any>;
+  children?: ReactNode;
+}
+
+export class Provider extends Component<ProviderProps, {}> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, Component, StatelessComponent, ReactNode } from 'react';
+import { ComponentClass, Component, StatelessComponent } from 'react';
 import { Store, Dispatch, ActionCreator } from 'redux';
 
 interface ComponentDecorator<TOriginalProps, TOwnProps> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
 }
 
 /**
- * Following 3 functions cover all possible ways connect could be invoked
+ * Following 5 functions cover all possible ways connect could be invoked
  *
  * - State: Redux state interface (the same one used by Store<S>)
  * - TOwnProps: Props passed to the wrapping component
@@ -40,18 +40,8 @@ interface MapStateToProps<State, TOwnProps, TStateProps> {
   (state: State, ownProps: TOwnProps): TStateProps;
 }
 
-/**
- * State is not actually used here but included for consistency with Redux typings and MapStateToProps.
- */
 interface MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> {
   (dispatch: Dispatch<State>, ownProps: TOwnProps): TDispatchProps;
-}
-
-/**
- * Any since not every ActionCreator returns the same Action
- */
-interface MapDispatchToPropsObject<TDispatchProps> {
-  [name: string]: ActionCreator<TDispatchProps>;
 }
 
 interface MergeProps<TOwnProps, TStateProps, TDispatchProps> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,10 +29,10 @@ export function connect<State, TOwnProps, TDispatchProps>(
   mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps
 ): ComponentDecorator<TDispatchProps, TOwnProps>;
 
-export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
+export function connect<State, TOwnProps, TStateProps, TDispatchProps, TMergeProps>(
   mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
   mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps,
-  mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps>,
+  mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps>,
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
@@ -44,8 +44,8 @@ interface MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> {
   (dispatch: Dispatch<State>, ownProps: TOwnProps): TDispatchProps;
 }
 
-interface MergeProps<TOwnProps, TStateProps, TDispatchProps> {
-  (ownProps: TOwnProps, stateProps: TStateProps, dispatchProps: TDispatchProps): TStateProps & TDispatchProps;
+interface MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps> {
+  (ownProps: TOwnProps, stateProps: TStateProps, dispatchProps: TDispatchProps): TMergeProps;
 }
 
 interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,9 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
  * Following 3 functions cover all possible ways connect could be invoked
  *
  * - State: Redux state interface (the same one used by Store<S>)
+ * - TOwnProps: Props passed to the wrapping component
  * - TStateProps: Result of MapStateToProps
  * - TDispatchProps: Result of MapDispatchToProps
- * - TOwnProps: Props passed to the wrapping component
  */
 export function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> }, TOwnProps>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,18 +16,23 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
 export function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> }, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps>(
-  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
+  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
 ): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> }, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
-  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>|null,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|TDispatchProps
+  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
+export function connect<State, TOwnProps, TDispatchProps>(
+  mapStateToProps: null,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps
+): ComponentDecorator<TDispatchProps, TOwnProps>;
+
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
-  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>|null,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|TDispatchProps,
-  mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
+  mapStateToProps: MapStateToProps<State, TOwnProps, TStateProps>,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>|TDispatchProps,
+  mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps>,
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,14 +13,18 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
  * - TDispatchProps: Result of MapDispatchToProps
  * - TOwnProps: Props passed to the wrapping component
  */
-export function connect<TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<any> }, TOwnProps>;
+export function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> }, TOwnProps>;
 
-export function connect<State, TStateProps, TDispatchProps, TOwnProps>(
+export function connect<State, TOwnProps, TStateProps>(
   mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
-  mapDispatchToProps?: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject
+): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> }, TOwnProps>;
+
+export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
+  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
-export function connect<State, TStateProps, TDispatchProps, TOwnProps>(
+export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
   mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
   mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
   mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
@@ -28,7 +32,7 @@ export function connect<State, TStateProps, TDispatchProps, TOwnProps>(
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 interface MapStateToProps<State, TStateProps, TOwnProps> {
-  (state: State, ownProps?: TOwnProps): TStateProps;
+  (state: State, ownProps: TOwnProps): TStateProps;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,14 +36,14 @@ export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
-interface MapStateToProps<State, TStateProps, TOwnProps> {
+interface MapStateToProps<State, TOwnProps, TStateProps> {
   (state: State, ownProps: TOwnProps): TStateProps;
 }
 
 /**
  * State is not actually used here but included for consistency with Redux typings and MapStateToProps.
  */
-interface MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps> {
+interface MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> {
   (dispatch: Dispatch<State>, ownProps: TOwnProps): TDispatchProps;
 }
 
@@ -54,8 +54,8 @@ interface MapDispatchToPropsObject<TDispatchProps> {
   [name: string]: ActionCreator<TDispatchProps>;
 }
 
-interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {
-  (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TStateProps & TDispatchProps;
+interface MergeProps<TOwnProps, TStateProps, TDispatchProps> {
+  (ownProps: TOwnProps, stateProps: TStateProps, dispatchProps: TDispatchProps): TStateProps & TDispatchProps;
 }
 
 interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,13 +20,13 @@ export function connect<State, TOwnProps, TStateProps>(
 ): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> }, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
-  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject
+  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>|null,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|TDispatchProps
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
-  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>,
-  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|MapDispatchToPropsObject,
+  mapStateToProps: MapStateToProps<State, TStateProps, TOwnProps>|null,
+  mapDispatchToProps: MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps>|TDispatchProps,
   mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
   options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
@@ -39,14 +39,14 @@ interface MapStateToProps<State, TStateProps, TOwnProps> {
  * State is not actually used here but included for consistency with Redux typings and MapStateToProps.
  */
 interface MapDispatchToPropsFunction<State, TDispatchProps, TOwnProps> {
-  (dispatch: Dispatch<State>, ownProps?: TOwnProps): TDispatchProps;
+  (dispatch: Dispatch<State>, ownProps: TOwnProps): TDispatchProps;
 }
 
 /**
  * Any since not every ActionCreator returns the same Action
  */
-interface MapDispatchToPropsObject {
-  [name: string]: ActionCreator<any>;
+interface MapDispatchToPropsObject<TDispatchProps> {
+  [name: string]: ActionCreator<TDispatchProps>;
 }
 
 interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,28 +13,28 @@ interface ComponentDecorator<TOriginalProps, TOwnProps> {
  * - TStateProps: Result of MapStateToProps
  * - TDispatchProps: Result of MapDispatchToProps
  */
-export function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> }, TOwnProps>;
+function connect<State, TOwnProps>(): ComponentDecorator<{ dispatch: Dispatch<State> } & TOwnProps, TOwnProps>;
 
-export function connect<State, TOwnProps, TStateProps>(
+function connect<State, TOwnProps, TStateProps>(
   mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
-): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> }, TOwnProps>;
+): ComponentDecorator<TStateProps & { dispatch: Dispatch<State> } & TOwnProps, TOwnProps>;
 
-export function connect<State, TOwnProps, TStateProps, TDispatchProps>(
+function connect<State, TOwnProps, TStateProps, TDispatchProps>(
   mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
   mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>
-): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+): ComponentDecorator<TStateProps & TDispatchProps & TOwnProps, TOwnProps>;
 
-export function connect<State, TOwnProps, TDispatchProps>(
+function connect<State, TOwnProps, TDispatchProps>(
   mapStateToProps: null,
   mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>
-): ComponentDecorator<TDispatchProps, TOwnProps>;
+): ComponentDecorator<TDispatchProps & TOwnProps, TOwnProps>;
 
-export function connect<State, TOwnProps, TStateProps, TDispatchProps, TMergeProps>(
+function connect<State, TOwnProps, TStateProps, TDispatchProps, TMergeProps>(
   mapStateToProps: FuncOrSelf<MapStateToProps<State, TOwnProps, TStateProps>>,
-  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> | MapDispatchToPropsObject & TDispatchProps>,
+  mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps>| MapDispatchToPropsObject & TDispatchProps>,
   mergeProps: MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps>,
   options?: Options
-): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
+): ComponentDecorator<TMergeProps, TOwnProps>;
 
 interface MapDispatchToPropsObject {
   [name: string]: ActionCreator<any>;
@@ -49,7 +49,7 @@ interface MapDispatchToPropsFunction<State, TOwnProps, TDispatchProps> {
 }
 
 interface MergeProps<TOwnProps, TStateProps, TDispatchProps, TMergeProps> {
-  (ownProps: TOwnProps, stateProps: TStateProps, dispatchProps: TDispatchProps): TMergeProps;
+  (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergeProps;
 }
 
 interface Options {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.4.5",
   "description": "Official React bindings for Redux",
   "main": "./lib/index.js",
+  "typings": "./index.d.ts",
   "scripts": {
     "build:lib": "babel src --out-dir lib",
     "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/react-redux.js",
@@ -22,7 +23,8 @@
   "files": [
     "dist",
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "keywords": [
     "react",


### PR DESCRIPTION
See #433 for discussion.

I tried using DT's but I found some issues (connect with no argument was not adding dispatch prop, and some API calls where not possible). I fixed the issues for the most common use cases, described below.
The rest of the API should work like it does with DT version.
Please note: **always define templates for your connect calls** or you **will** have issues/subpar type checking (inference engine will replace non-inferable templates type with `{}`).

API Ref that we should targeted as much as possible: https://github.com/reactjs/react-redux/blob/master/docs/api.md#examples

These are the supported use cases that I tested and that 100% type check without any error or leniency:

### 1. Inject `dispatch` and don't listen to store

```typescript
import { Dispatch } from 'redux'
import { checkout } from '../actions'
type AppState = {}

interface OwnProps {
  cartId: number
}

interface P extends OwnProps {
  dispatch: Dispatch<AppState> // try removing it, you'll get an error
}

class Cart extends Component<P, {}> {
  this.props.dispatch(checkout(this.props.cartId))
}

export default connect<AppState, OwnProps>()(Cart)
```
- `AppState` is used as a template for the Dispatch type, as required by redux typings
- `OwnProps` exposes the component with its props signature, without complicated `InferableComponentDecorator` that won't allow me to inject dispatcher.

### 2. Hydrate action creators without subscribing to the store

```typescript
import { Dispatch } from 'redux'
import { checkout } from '../actions'

interface OwnProps {
  cartId: number
}

interface DispatchProps {
  checkout: (cartId: number) => void
}

interface P extends OwnProps, DispatchProps {}

class Cart extends Component<P, {}> {
  this.props.checkout(this.props.cartId) // checkout is hydrated
}

connect<{}, OwnProps, DispatchProps>(null, { checkout })(Cart)
```

### 3. Inject `dispatch` and props from global state

```typescript
import { Dispatch } from 'redux'
import { checkout } from '../actions'

type AppState = {
  items: {
    [cartId: number]: Item[]
  }
}

interface OwnProps {
  cartId: number
}

interface StateProps { 
  items: Item[],
}

interface P extends OwnProps, StateProps {
  dispatch: Dispatch<AppState>
}

class Cart extends Component<P, {}> {
  this.props.dispatch(checkout(this.props.cartId))
  this.props.items.each(item => ...)
}

export default connect<AppState, OwnProps, StateProps>((state, props) => ({
  // state, props and result hash are all completely safe
  items: state.items[props.cartId]
}))(Cart)
```

### 4. Inject props from global state and hydrate action creators

```typescript

type AppState = {
  items: {
    [cartId: number]: Item[]
  }
}

interface OwnProps {
  cartId: number
}

interface StateProps {
  items: Item[],
}

interface DispatchProps {
  checkout: (cartId: number) => void
}

interface P extends OwnProps, StateProps, DispatchProps {}

class Cart extends Component<P, {}> {
  this.props.checkout(this.props.cartId)
  this.props.items.each(item => ...)
}

export default connect<AppState, OwnProps, StateProps, DispatchProps>((state, props) => ({
  items: state.items[props.cartId]
}), { checkout })(Cart)
```
- `AppState` describes your App's state
- `OwnProps` describes your component's outside props (the ones that the parent component should specify)
- `StateProps` describes the component's props that come from the global state
- `DispatchProps` describes the component's props that come from hydrated action creators

Honestly, I only use case **(3.)**

This should get us started. Please feedback!