### PR TITLE
Adds react15CompatibilityMode setting

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -20,7 +20,7 @@ function warnAboutReceivingStore() {
 
 export default class Provider extends Component {
   getChildContext() {
-    return { store: this.store }
+    return { store: this.store, react15CompatibilityMode: this.props.react15CompatibilityMode }
   }
 
   constructor(props, context) {
@@ -45,10 +45,15 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 Provider.propTypes = {
+  react15CompatibilityMode: PropTypes.bool,
   store: storeShape.isRequired,
   children: PropTypes.element.isRequired
 }
 Provider.childContextTypes = {
+  react15CompatibilityMode: PropTypes.bool.isRequired,
   store: storeShape.isRequired
+}
+Provider.defaultProps = {
+  react15CompatibilityMode: true
 }
 Provider.displayName = 'Provider'

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -20,7 +20,7 @@ function warnAboutReceivingStore() {
 
 export default class Provider extends Component {
   getChildContext() {
-    return { store: this.store, react15CompatibilityMode: this.props.react15CompatibilityMode }
+    return { store: this.store }
   }
 
   constructor(props, context) {
@@ -45,15 +45,10 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 Provider.propTypes = {
-  react15CompatibilityMode: PropTypes.bool,
   store: storeShape.isRequired,
   children: PropTypes.element.isRequired
 }
 Provider.childContextTypes = {
-  react15CompatibilityMode: PropTypes.bool.isRequired,
   store: storeShape.isRequired
-}
-Provider.defaultProps = {
-  react15CompatibilityMode: true
 }
 Provider.displayName = 'Provider'

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -18,7 +18,7 @@ export default function connectAdvanced(
 
     Access to dispatch is provided to the factory so selectorFactories can bind actionCreators
     outside of their selector as an optimization. Options passed to connectAdvanced are passed to
-    the selectorFactory, along with displayName and WrappedComponent, as the second argument. 
+    the selectorFactory, along with displayName and WrappedComponent, as the second argument.
 
     Note that selectorFactory is responsible for all caching/memoization of inbound and outbound
     props. Do not use connectAdvanced directly without memoizing results between calls to your
@@ -35,8 +35,8 @@ export default function connectAdvanced(
     // probably overridden by wrapper functions such as connect()
     methodName = 'connectAdvanced',
 
-    // temporary setting. See Connect constructor for details
-    react15CompatibilityMode = undefined,
+    // temporary compatibility setting for React 15. See Connect constructor for details
+    react15CompatibilityMode = true,
 
     // if defined, the name of the property passed to the wrapped element indicating the number of
     // calls to render. useful for watching in react devtools for unnecessary re-renders.
@@ -59,13 +59,12 @@ export default function connectAdvanced(
   const version = hotReloadingVersion++
 
   const contextTypes = {
-    react15CompatibilityMode: PropTypes.bool,
     [storeKey]: storeShape,
     [subscriptionKey]: PropTypes.instanceOf(Subscription)
   }
   const childContextTypes = {
     [subscriptionKey]: PropTypes.instanceOf(Subscription)
-  }  
+  }
 
   return function wrapWithConnect(WrappedComponent) {
     invariant(
@@ -100,16 +99,13 @@ export default function connectAdvanced(
         this.state = {}
         this.renderCount = 0
         this.store = this.props[storeKey] || this.context[storeKey]
+        this.parentSub = props[subscriptionKey] || context[subscriptionKey]
 
         // react15CompatibilityMode controls whether the subscription system is used. This is for
         // https://github.com/reactjs/react-redux/issues/525 and should be removed completely when
         // react-redux's dependency on react is bumped to mimimum v16, which is expected to include
-        // PR https://github.com/facebook/react/pull/8204 which fixes the issue. If it's passed via
-        // an options arg, use that value, otherwise use the value from props/context.
-        const compat = react15CompatibilityMode !== undefined && react15CompatibilityMode !== null
-          ? react15CompatibilityMode
-          : (props.react15CompatibilityMode || context.react15CompatibilityMode);
-        this.parentSub = !compat ? (props[subscriptionKey] || context[subscriptionKey]) : null
+        // PR https://github.com/facebook/react/pull/8204 which fixes the issue.
+        if (react15CompatibilityMode) this.parentSub = null
 
         this.setWrappedInstance = this.setWrappedInstance.bind(this)
 

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -5,6 +5,8 @@ import { Component, PropTypes, createElement } from 'react'
 import Subscription from '../utils/Subscription'
 import storeShape from '../utils/storeShape'
 
+
+let defaultReact15CompatibilityMode = true
 let hotReloadingVersion = 0
 export default function connectAdvanced(
   /*
@@ -36,7 +38,7 @@ export default function connectAdvanced(
     methodName = 'connectAdvanced',
 
     // temporary compatibility setting for React 15. See Connect constructor for details
-    react15CompatibilityMode = true,
+    react15CompatibilityMode = undefined,
 
     // if defined, the name of the property passed to the wrapped element indicating the number of
     // calls to render. useful for watching in react devtools for unnecessary re-renders.
@@ -60,7 +62,8 @@ export default function connectAdvanced(
 
   const contextTypes = {
     [storeKey]: storeShape,
-    [subscriptionKey]: PropTypes.instanceOf(Subscription)
+    [subscriptionKey]: PropTypes.instanceOf(Subscription),
+    react15CompatibilityMode: PropTypes.bool,
   }
   const childContextTypes = {
     [subscriptionKey]: PropTypes.instanceOf(Subscription)
@@ -99,13 +102,18 @@ export default function connectAdvanced(
         this.state = {}
         this.renderCount = 0
         this.store = this.props[storeKey] || this.context[storeKey]
-        this.parentSub = props[subscriptionKey] || context[subscriptionKey]
-
+        
         // react15CompatibilityMode controls whether the subscription system is used. This is for
         // https://github.com/reactjs/react-redux/issues/525 and should be removed completely when
         // react-redux's dependency on react is bumped to mimimum v16, which is expected to include
         // PR https://github.com/facebook/react/pull/8204 which fixes the issue.
-        if (react15CompatibilityMode) this.parentSub = null
+        const compatMode = [
+          react15CompatibilityMode,
+          props.react15CompatibilityMode,
+          context.react15CompatibilityMode,
+          defaultReact15CompatibilityMode
+        ].find(cm => cm !== undefined && cm !== null)
+        this.parentSub = compatMode ? null : props[subscriptionKey] || context[subscriptionKey]
 
         this.setWrappedInstance = this.setWrappedInstance.bind(this)
 
@@ -266,3 +274,9 @@ export default function connectAdvanced(
     return hoistStatics(Connect, WrappedComponent)
   }
 }
+
+connectAdvanced.setDefaultReact15CompatibilityMode =
+  function setDefaultReact15CompatibilityMode(compat) {
+    defaultReact15CompatibilityMode = compat
+  }
+

--- a/src/connect/connect.js
+++ b/src/connect/connect.js
@@ -84,4 +84,6 @@ export function createConnect({
   }
 }
 
-export default createConnect()
+const connect = createConnect()
+connect.setDefaultReact15CompatibilityMode = connectAdvanced.setDefaultReact15CompatibilityMode
+export default connect

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -152,7 +152,7 @@ describe('React', () => {
     }
 
     const tree = TestUtils.renderIntoDocument(
-      <Provider store={store}>
+      <Provider store={store} react15CompatibilityMode={false}>
         <Container />
       </Provider>
     )

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -152,7 +152,7 @@ describe('React', () => {
     }
 
     const tree = TestUtils.renderIntoDocument(
-      <Provider store={store} react15CompatibilityMode={false}>
+      <Provider store={store}>
         <Container />
       </Provider>
     )

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -144,7 +144,7 @@ describe('React', () => {
       // The state from parent props should always be consistent with the current state
       expect(state).toEqual(parentProps.parentState)
       return {}
-    })
+    }, null, null, { react15CompatibilityMode: false })
     class ChildContainer extends Component {
       render() {
         return <div />

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1698,7 +1698,7 @@ describe('React', () => {
         // The state from parent props should always be consistent with the current state
         expect(state).toEqual(parentProps.parentState)
         return {}
-      })
+      }, null, null, { react15CompatibilityMode: false })
       class ChildContainer extends Component {
         render() {
           return <Passthrough {...this.props}/>


### PR DESCRIPTION
`react15CompatibilityMode` is intended to be a temporary setting until our official solution is "use React v16." When set to true, which is the default in `<Provider>`, subscriptions are **not** re-ordered to fire top-down. This avoids the bug related to #525 but loses some of the perf gains and re-introduces the issues with state and ownProps being out of sync. This should behave pretty much like react-redux v4.

A developer that upgrades to this version w/o making any other changes should not experience the #525 bug out of the box, but won't get the good stuff mentioned above.

The recommended upgrade path is to set `react15CompatibilityMode` to false at the `<Provider>` level and then set it to true at the component level for all `connect`ed text inputs. This can be done either as a prop (confirmed working with redux-form's `<Field>` component) or as an options arg to `connect`. Those inputs are now vulnerable to the state/props sync issue that exists in v4, but will not have the #525 cursor issue.

Apps using React v16 (or whatever version includes https://github.com/facebook/react/pull/8204), or using Preact as a drop-in replacement for React should not have to set `react15CompatibilityMode` to true at the component level at all... just set `<Provider react15CompatibilityMode={false}>` .

Once React v16 becomes the popular choice, we can switch the default from true to false. Once v15 support is dropped, we can backout this change completely.


