### PR TITLE
Add "^15.4.0-0" to compatible react peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "loose-envify": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0",
+    "react": "^0.14.0 || ^15.0.0-0 || ^15.4.0-0",
     "redux": "^2.0.0 || ^3.0.0"
   },
   "browserify": {


### PR DESCRIPTION
In order to satisfy a prerelease version, the major/minor/patch versions must match exactly. This change makes `react-redux` `yarn` friendly when used with `react@15.4.0-rc.4`. Without this change, you always fail a `yarn check`.

cc: @gaearon @bestander.

