### PR TITLE
Use isSubscribed method

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -195,7 +195,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
       }
 
       trySubscribe() {
-        if (shouldSubscribe && !this.unsubscribe) {
+        if (shouldSubscribe && !this.isSubscribed()) {
           this.unsubscribe = this.store.subscribe(this.handleChange.bind(this))
           this.handleChange()
         }


### PR DESCRIPTION
`isSubscribed` method was unused. This makes use of that method internally to determine if the component should subscribe.