### PR TITLE
Fixes #525 (cursor bug) by moving notify from setState callback to componentDidUpdate.

### DIFF
--- a/src/connect/connect.js
+++ b/src/connect/connect.js
@@ -87,6 +87,4 @@ export function createConnect({
   }
 }
 
-const connect = createConnect()
-connect.setDefaultReact15CompatibilityMode = connectAdvanced.setDefaultReact15CompatibilityMode
-export default connect
+export default createConnect()

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -144,7 +144,7 @@ describe('React', () => {
       // The state from parent props should always be consistent with the current state
       expect(state).toEqual(parentProps.parentState)
       return {}
-    }, null, null, { react15CompatibilityMode: false })
+    })
     class ChildContainer extends Component {
       render() {
         return <div />

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1697,7 +1697,7 @@ describe('React', () => {
         // The state from parent props should always be consistent with the current state
         expect(state).toEqual(parentProps.parentState)
         return {}
-      }, null, null, { react15CompatibilityMode: false })
+      })
       class ChildContainer extends Component {
         render() {
           return <Passthrough {...this.props}/>


### PR DESCRIPTION
Instead of using the `setState` callback, doing `notifyNestedSubs` in `componentDidUpdate` seems to avoid the cursor bug (#525) without the need for the compatibility setting BS. (I swear the first time I tried this, it didn't work; I must've screwed something up. /shruggie) I'll perf test this tonight when I'm at my home PC with all my test projects. Assuming that goes well, this is a much cleaner solution. Thanks @istarkov.

