### PR TITLE
Eliminate addtional notifications to nested components

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -200,11 +200,6 @@ export default function connectAdvanced(
             if (!this.selector.shouldComponentUpdate) {
               subscription.notifyNestedSubs()
             } else {
-              this.componentDidUpdate = function componentDidUpdate() {
-                this.componentDidUpdate = undefined
-                subscription.notifyNestedSubs()
-              }
-
               this.setState(dummyState)
             }
           }.bind(this)

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -136,6 +136,9 @@ export default function connectAdvanced(
 
       componentWillReceiveProps(nextProps) {
         this.selector.run(nextProps)
+        if (!this.selector.shouldComponentUpdate && this.subscription) {
+          this.subscription.notifyNestedSubs()
+        }
       }
 
       shouldComponentUpdate() {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -909,6 +909,46 @@ describe('React', () => {
       expect(mapStateToPropsCalls).toBe(1)
     })
 
+    it('should notify mounted child of state change', () => {
+      const store = createStore(stringBuilder)
+
+      @connect((state) => ({ string: state.slice(0, 1) }))
+      class App extends Component {
+        render() {
+          return <Container />
+        }
+      }
+
+      @connect(() => ({}))
+      class Container extends Component {
+        render() {
+          return (
+            <Child />
+          )
+        }
+      }
+
+      let mapStateToPropsCalls = 0
+      @connect(() => ({ calls: ++mapStateToPropsCalls }))
+      class Child extends Component {
+        render() {
+          return null;
+        }
+      }
+
+      const div = document.createElement('div')
+      ReactDOM.render(
+        <ProviderMock store={store}>
+          <App />
+        </ProviderMock>,
+        div
+      )
+      store.dispatch({ type: 'APPEND', body: 'A' })
+      expect(mapStateToPropsCalls).toBe(2)
+      store.dispatch({ type: 'APPEND', body: 'B' })
+      expect(mapStateToPropsCalls).toBe(3)
+    })
+
     it('should not attempt to notify unmounted child of state change', () => {
       const store = createStore(stringBuilder)
 


### PR DESCRIPTION
When handling store updates, selector is sometimes called twice with same `state` and `ownProps` for nested components. I traced this part, and found things occurred in following order:

`parent: onStateChange, setState`
`nested: componentWillReceiveProps, selector, shouldComponentUpdate`
`parent: componentDidUpdate, notifyNestedSubs`
`nested: onStateChange, selector, (skip update), notifyNestedSubs`

The nested component was updated twice for one store update, by receiving (new?) `props`(`setState`), and being notified(`notifyNestedSubs`).

I tried to eliminate additional update attempts by removing `componentDidUpdate`, and run test to see how many cases would break...

> `63 passing (441ms)`

All test are passed, but it should not.

Nested components are *notified* by `setState` or `notifyNestedSubs` in `onStateChange`, or by React after receiving `props`. If React is told not to update after receiving `props`, all nested components should be notified by `notifyNestedSubs`, this is added to `componentWillReceiveProps`.