### PR TITLE
Add the link to connectAdvanced to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@
 - [API](api.md#api)
   - [`<Provider store>`](api.md#provider-store)
   - [`connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])`](api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
+  - [`connectAdvanced(selectorFactory, [connectOptions])`](api.md#connectadvancedselectorfactory-connectoptions)
 - [Troubleshooting](troubleshooting.md#troubleshooting)


### PR DESCRIPTION
I just noticed that it was missing.

(Sorry for not having opened an issue before opening this pr, but i think this is quite straightforward)
