### PR TITLE
fix(connect): should not call update if props has not changed

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -90,6 +90,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         )
 
         const storeState = this.store.getState()
+        this.prevStoreState = storeState
         this.state = { storeState }
         this.clearCache()
       }
@@ -242,10 +243,11 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         }
 
         const storeState = this.store.getState()
-        const prevStoreState = this.state.storeState
-        if (pure && prevStoreState === storeState) {
+        if (pure && this.prevStoreState === storeState) {
           return
         }
+
+        this.prevStoreState = storeState
 
         if (pure && !this.doStatePropsDependOnOwnProps) {
           const haveStatePropsChanged = tryCatch(this.updateStatePropsIfNeeded, this)


### PR DESCRIPTION
- I dispatch a action, If the props value has not changed but it return new props.
- Next, I dispatch a action that not match, it return the prev props

the **react-redux@4.x** will call update to compute props, see the below example:

The reducer like this:

```js
const reducer = (prev = {}, action) => {
  return action.type === 'NOT_CHANGED'
    ? { ...prev, ...action.payload }
    : prev
}
```

And do these action:

```js
// cuz the props reference has changed, it will call update but the props value has not changed
store.dispatch({ type: 'NOT_CHANGED', payload: {} })

// then I dispatch the action that not match, the props has not changed, it will call update again
store.dispatch({ type: 'NOT_MATCH' })
```

Find source code **handleChange**:

```js
handleChange() {
  if (!this.unsubscribe) {
    return
  }

  const storeState = this.store.getState()
  const prevStoreState = this.state.storeState
  if (pure && prevStoreState === storeState) {
    return
  }

  if (pure && !this.doStatePropsDependOnOwnProps) {
    const haveStatePropsChanged = tryCatch(this.updateStatePropsIfNeeded, this)
    // if props has not changed and return
    // but the prev storeState has not updated, it will cause the next storeState check is wrong
    if (!haveStatePropsChanged) {
      return
    }
    if (haveStatePropsChanged === errorObject) {
      this.statePropsPrecalculationError = errorObject.value
    }
    this.haveStatePropsBeenPrecalculated = true
  }

  this.hasStoreStateChanged = true
  this.setState({ storeState })
}
```

I do this case with **react-redux@5.x**, this problem has not exist.