### PR TITLE
Stringify wrong argument for easier debugging

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -67,7 +67,7 @@ export default function connectAdvanced(
     invariant(
       typeof WrappedComponent == 'function',
       `You must pass a component to the function returned by ` +
-      `connect. Instead received ${WrappedComponent}`
+      `connect. Instead received ${JSON.stringify(WrappedComponent)}`
     )
 
     const wrappedComponentName = WrappedComponent.displayName


### PR DESCRIPTION
Produce more meaningfull message in case of receiving not a function.