### PR TITLE
Combine components the same way you combine reducers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,9 @@
 
 - [Redux: Usage with React](http://redux.js.org/docs/basics/UsageWithReact.html)
 - [API](api.md#api)
-  - [`<Provider store>`](api.md#provider-store)
-  - [`connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])`](api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
-  - [`connectAdvanced(selectorFactory, [connectOptions])`](api.md#connectadvancedselectorfactory-connectoptions)
+  - [`<Provider store>`](api.md#provider)
+  - [`<SubProvider subState>`](api.md#subprovider)
+  - [`connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])`](api.md#connect)
+  - [`connectAdvanced(selectorFactory, [connectOptions])`](api.md#connectadvanced)
+  - [`combineConnected(components)`](api.md#combineConnected)
 - [Troubleshooting](troubleshooting.md#troubleshooting)

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,33 @@ ReactDOM.render(
 )
 ```
 
+<a id="subprovider"></a>
+### `<SubProvider subState>`
+
+Makes a proxy Redux store available to the `connect()` calls in the component hierarchy below. `subscribe()` and `dispatch()` calls on the proxy are passed to the application's single Redux store, but calls to `getState()` only return the value of `state[subState]`. Allows `connect()'ed components to be unaware of their data's location in the parent state.
+
+#### Props
+
+* `subState` (*string*): The property of the parent state object to return from `getState()`.
+* `children` (*ReactElement*) The root of your component hierarchy.
+
+#### Example
+
+```js
+ReactDOM.render(
+  <Provider store={store}>
+    <div>
+      <SubProvider subState="todos">
+        <MyTodosComponent />
+      </SubProvider>
+      <SubProvider subState="calender">
+        <MyCalendarComponent />
+      </SubProvider>
+    </div>
+  </Provider>,
+  rootEl
+)
+```
 
 <a id="connect"></a>
 ### `connect([mapStateToProps], [mapDispatchToProps], [mergeProps], [options])`
@@ -378,3 +405,72 @@ function selectorFactory(dispatch) {
 export default connectAdvanced(selectorFactory)(TodoApp)
 ```
 
+<a id="combineConnected"></a>
+### `combineConnected(components)`
+
+Takes an object whose values are `connect()`ed components and wraps them in `SubProviders` so that each component only receives one property of the state object.
+
+Similarly to `combineReducers()`, the property each component receives is controlled by the keys of the argument.
+
+It does not modify the component classes passed to it; instead, it *returns* new component classes for you to use.
+
+<a id="combineConnected-arguments"></a>
+#### Arguments
+
+* `components` \(*Object*): An object whose values are `connect()`ed components and whose keys are properties of the state object which they should receive in place of the parent state.
+
+The values of the object can also be objects with a single key, which names their single value (the component itself).
+
+#### Returns
+
+An object whose values are higher-order React component classes, which pass one property of the parent state object to your components, derived from the supplied argument's keys.
+
+The keys are either the same as the keys of the provided argument, *or* if the component was named as above, the key will be the name. This can be more convenient for destructuring the result object (see examples).
+
+#### Examples
+
+##### 
+```js
+/* 
+ * mapStateToProps only cares about local state, not its
+ * location in the global state object
+ */
+const mapStateToTodosProps = (state) => ({ todos: state });
+let myTodos = (props) => <Todos {...props}>;
+myTodos = connect(mapStateToTodosProps)(myTodos);
+
+const mapStateToCalendarProps = (state) => ({ calendar: state });
+let myCalendar = (props) => <Calendar {...props}>;
+myCalendar = connect(mapStateToTodosProps)(myCalendar);
+
+/*
+ * Combine the components so they only receive their local state
+ */
+// With manual result destructuring
+({ todos: myTodos, calendar: myCalendar } = combineConnected({
+  todos: myTodos,
+  calendar: myCalendar
+});
+
+// With named result destructuring
+({ myTodos, myCalendar } = combineConnected({
+  todos: { myTodos: myTodos },
+  calendar: { myCalendar: myCalendar }
+});
+
+// Or with shorthand notation
+({ myTodos, myCalendar } = combineConnected({
+  todos: { myTodos },
+  calendar: { myCalendar }
+}));
+
+ReactDOM.render(
+  <Provider store={store}>
+    <div>
+      <myTodos />
+      <myCalendar />
+    </div>
+  </Provider>,
+  rootEl
+)
+```

--- a/src/components/SubProvider.js
+++ b/src/components/SubProvider.js
@@ -1,0 +1,31 @@
+import { PropTypes } from 'react'
+import Provider from './Provider'
+import Subscription from '../utils/Subscription'
+import storeShape from '../utils/storeShape'
+
+export default class SubProvider extends Provider {
+  getChildContext() {
+    return { store: this.subStore, storeSubscription: this.storeSubscription }
+  }
+
+  constructor(props, context) {
+    super(props, context)
+    const store = context.store;
+    this.storeSubscription = context.storeSubscription;
+    this.subStore = {
+      subscribe: store.subscribe.bind(store),
+      dispatch: store.dispatch.bind(store),
+      getState: () => store.getState()[props.subState]
+    };
+  }
+}
+
+SubProvider.propTypes = {
+  subState: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired
+}
+SubProvider.contextTypes = {
+  store: storeShape,
+  storeSubscription: PropTypes.instanceOf(Subscription)
+}
+SubProvider.displayName = 'SubProvider'

--- a/src/components/combine.js
+++ b/src/components/combine.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import SubProvider from './SubProvider';
+
+const subStateHOC = (subState) => {
+  return (WrappedComponent) => {
+    return class Combine extends React.Component {
+      render() {
+        return (
+          <SubProvider subState={ subState }>
+            <WrappedComponent {...this.props}/>
+          </SubProvider>
+        );
+      }
+    };
+  };
+};
+
+export const subStateWrapper = subStateHOC;
+
+const combineConnected = (components) => {
+  const combined = {};
+  for (const subState in components) {
+    const keys = Object.keys(components[subState]);
+
+    const isNamed = (
+      typeof components[subState] === 'object' &&
+      keys.length === 1
+    ); 
+
+    const name = isNamed ? keys[0] : subState;
+
+    const result = isNamed ?
+      subStateWrapper(subState)(components[subState][name]) :
+      subStateWrapper(subState)(components[subState]);
+
+    combined[name] = result;
+  }
+  return combined;
+};
+
+export default combineConnected;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import Provider from './components/Provider'
+import SubProvider from './components/SubProvider'
+import combineConnected from './components/combine';
 import connectAdvanced from './components/connectAdvanced'
 import connect from './connect/connect'
 
-export { Provider, connectAdvanced, connect }
+export { Provider, SubProvider, combineConnected, connectAdvanced, connect }

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -132,68 +132,68 @@ describe('React', () => {
       innerStore.dispatch({ type: 'INC'})
       expect(innerMapStateToProps.calls.length).toBe(2)
     })
-  })
 
-  it('should pass state consistently to mapState', () => {
-    function stringBuilder(prev = '', action) {
-      return action.type === 'APPEND'
-        ? prev + action.body
-        : prev
-    }
-
-    const store = createStore(stringBuilder)
-
-    store.dispatch({ type: 'APPEND', body: 'a' })
-    let childMapStateInvokes = 0
-
-    @connect(state => ({ state }), null, null, { withRef: true })
-    class Container extends Component {
-      emitChange() {
-        store.dispatch({ type: 'APPEND', body: 'b' })
+    it('should pass state consistently to mapState', () => {
+      function stringBuilder(prev = '', action) {
+        return action.type === 'APPEND'
+          ? prev + action.body
+          : prev
       }
 
-      render() {
-        return (
-          <div>
-            <button ref="button" onClick={this.emitChange.bind(this)}>change</button>
-            <ChildContainer parentState={this.props.state} />
-          </div>
-        )
-      }
-    }
+      const store = createStore(stringBuilder)
 
-    @connect((state, parentProps) => {
-      childMapStateInvokes++
-      // The state from parent props should always be consistent with the current state
-      expect(state).toEqual(parentProps.parentState)
-      return {}
+      store.dispatch({ type: 'APPEND', body: 'a' })
+      let childMapStateInvokes = 0
+
+      @connect(state => ({ state }), null, null, { withRef: true })
+      class Container extends Component {
+        emitChange() {
+          store.dispatch({ type: 'APPEND', body: 'b' })
+        }
+
+        render() {
+          return (
+            <div>
+              <button ref="button" onClick={this.emitChange.bind(this)}>change</button>
+              <ChildContainer parentState={this.props.state} />
+            </div>
+          )
+        }
+      }
+
+      @connect((state, parentProps) => {
+        childMapStateInvokes++
+        // The state from parent props should always be consistent with the current state
+        expect(state).toEqual(parentProps.parentState)
+        return {}
+      })
+      class ChildContainer extends Component {
+        render() {
+          return <div />
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Container />
+        </Provider>
+      )
+
+      expect(childMapStateInvokes).toBe(1)
+
+      // The store state stays consistent when setState calls are batched
+      store.dispatch({ type: 'APPEND', body: 'c' })
+      expect(childMapStateInvokes).toBe(2)
+
+      // setState calls DOM handlers are batched
+      const container = TestUtils.findRenderedComponentWithType(tree, Container)
+      const node = container.getWrappedInstance().refs.button
+      TestUtils.Simulate.click(node)
+      expect(childMapStateInvokes).toBe(3)
+
+      // Provider uses unstable_batchedUpdates() under the hood
+      store.dispatch({ type: 'APPEND', body: 'd' })
+      expect(childMapStateInvokes).toBe(4)
     })
-    class ChildContainer extends Component {
-      render() {
-        return <div />
-      }
-    }
-
-    const tree = TestUtils.renderIntoDocument(
-      <Provider store={store}>
-        <Container />
-      </Provider>
-    )
-
-    expect(childMapStateInvokes).toBe(1)
-
-    // The store state stays consistent when setState calls are batched
-    store.dispatch({ type: 'APPEND', body: 'c' })
-    expect(childMapStateInvokes).toBe(2)
-
-    // setState calls DOM handlers are batched
-    const container = TestUtils.findRenderedComponentWithType(tree, Container)
-    const node = container.getWrappedInstance().refs.button
-    TestUtils.Simulate.click(node)
-    expect(childMapStateInvokes).toBe(3)
-
-    // Provider uses unstable_batchedUpdates() under the hood
-    store.dispatch({ type: 'APPEND', body: 'd' })
-    expect(childMapStateInvokes).toBe(4)
   })
 })

--- a/test/components/SubProvider.spec.js
+++ b/test/components/SubProvider.spec.js
@@ -1,0 +1,242 @@
+/*eslint-disable react/prop-types*/
+
+import expect from 'expect'
+import React, { PropTypes, Component } from 'react'
+import TestUtils from 'react-addons-test-utils'
+import { combineReducers, createStore } from 'redux'
+import { Provider, SubProvider, connect } from '../../src/index'
+
+describe('React', () => {
+  describe('SubProvider', () => {
+    class Child extends Component {
+
+      render() {
+        return <div />
+      }
+    }
+
+    Child.contextTypes = {
+      store: PropTypes.object.isRequired
+    }
+
+    it('should enforce a single child', () => {
+      const store = createStore(() => ({ key: "value" }))
+
+      // Ignore propTypes warnings
+      const propTypes = SubProvider.propTypes
+      SubProvider.propTypes = {}
+
+      try {
+        expect(() => TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <SubProvider subState="key">
+              <div />
+            </SubProvider>
+          </Provider>
+        )).toNotThrow()
+
+        expect(() => TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <SubProvider subState="key">
+            </SubProvider>
+          </Provider>
+        )).toThrow(/a single React element child/)
+
+        expect(() => TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <SubProvider subState="key">
+              <div />
+              <div />
+            </SubProvider>
+          </Provider>
+        )).toThrow(/a single React element child/)
+      } finally {
+        SubProvider.propTypes = propTypes
+      }
+    })
+
+    it('should add the store proxy to the child context', () => {
+      const store = createStore(() => ({ key: "value" }))
+
+      const spy = expect.spyOn(console, 'error')
+      const tree = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <SubProvider subState="key">
+            <Child />
+          </SubProvider>
+        </Provider>
+      )
+      spy.destroy()
+      expect(spy.calls.length).toBe(0)
+
+      const child = TestUtils.findRenderedComponentWithType(tree, Child)
+      const subProvider = TestUtils.findRenderedComponentWithType(tree, SubProvider)
+      expect(child.context.store).toBe(subProvider.subStore)
+    })
+
+    it('should pass store proxy calls to the real store', () => {
+      const store = createStore(() => ({ key: "value" }));
+
+      const subscribeSpy = expect.spyOn(store, "subscribe").andCallThrough();
+      const dispatchSpy = expect.spyOn(store, "dispatch").andCallThrough();
+      const getStateSpy = expect.spyOn(store, "getState").andCallThrough();
+
+      const spy = expect.spyOn(console, 'error')
+      const tree = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <SubProvider subState="key">
+            <Child />
+          </SubProvider>
+        </Provider>
+      )
+      spy.destroy()
+      expect(spy.calls.length).toBe(0)
+
+      const subProvider = TestUtils.findRenderedComponentWithType(tree, SubProvider)
+      subProvider.subStore.subscribe(() => {})
+      expect(subscribeSpy.calls.length).toBe(1);
+
+      subProvider.subStore.dispatch({ type: 'ACTION' })
+      expect(dispatchSpy.calls.length).toBe(1);
+
+      subProvider.subStore.getState()
+      expect(getStateSpy.calls.length).toBe(1);
+    })
+
+    it('should pass one property of state to mapStateToProps', () => {
+      let reducer = (state = 0, action) => (action.type === 'INC' ? state + 1 : state)
+
+      reducer = combineReducers({ count: reducer });
+      
+      const store = createStore(reducer)
+
+      const outerMapStateToProps = expect.createSpy().andCall(state => ({ count: state.count }))
+      @connect(outerMapStateToProps)
+      class Outer extends Component {
+        render() { return <div>{this.props.count}</div> }
+      }
+      const innerMapStateToProps = expect.createSpy().andCall(state => ({ count: state }))
+      @connect(innerMapStateToProps)
+      class Inner extends Component {
+        render() { return <div>{this.props.count}</div> }
+      }
+
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <div>
+            <Outer />
+            <SubProvider subState="count">
+              <Inner />
+            </SubProvider>
+          </div>
+        </Provider>)
+
+      expect(outerMapStateToProps.calls.length).toBe(1)
+      expect(outerMapStateToProps).toHaveBeenCalledWith({ count: 0 }, {});
+
+      expect(innerMapStateToProps.calls.length).toBe(1)
+      expect(innerMapStateToProps).toHaveBeenCalledWith(0, {});
+
+      store.dispatch({ type: 'INC'})
+
+      expect(outerMapStateToProps.calls.length).toBe(2)
+      expect(outerMapStateToProps).toHaveBeenCalledWith({ count: 1 }, {});
+
+      expect(innerMapStateToProps.calls.length).toBe(2)
+      expect(innerMapStateToProps).toHaveBeenCalledWith(1, {});
+
+    })
+
+    it('should handle subscriptions correctly when there is nested Providers', () => {
+      const innerReducer = (state = 0, action) => (action.type === 'INC' ? state + 1 : state)
+      
+      const innerStore = createStore(innerReducer)
+      const innerMapStateToProps = expect.createSpy().andCall(state => ({ count: state }))
+      @connect(innerMapStateToProps)
+      class Inner extends Component {
+        render() { return <div>{this.props.count}</div> }
+      }
+
+      const outerReducer = combineReducers({ i: innerReducer });
+
+      const outerStore = createStore(outerReducer)
+      @connect(state => ({ count: state }))
+      class Outer extends Component {
+        render() { return <Provider store={innerStore}><Inner /></Provider> }
+      }
+      
+      TestUtils.renderIntoDocument(<Provider store={outerStore}><SubProvider subState="i"><Outer /></SubProvider></Provider>)
+      expect(innerMapStateToProps.calls.length).toBe(1)
+
+      innerStore.dispatch({ type: 'INC'})
+      expect(innerMapStateToProps.calls.length).toBe(2)
+    })
+
+    it('should pass state consistently to mapState', () => {
+      function stringBuilder(prev = '', action) {
+        return action.type === 'APPEND'
+          ? prev + action.body
+          : prev
+      }
+
+      const store = createStore(combineReducers({
+        string: stringBuilder
+      }))
+
+      store.dispatch({ type: 'APPEND', body: 'a' })
+      let childMapStateInvokes = 0
+
+      @connect(state => ({ state }), null, null, { withRef: true })
+      class Container extends Component {
+        emitChange() {
+          store.dispatch({ type: 'APPEND', body: 'b' })
+        }
+
+        render() {
+          return (
+            <div>
+              <button ref="button" onClick={this.emitChange.bind(this)}>change</button>
+              <ChildContainer parentState={this.props.state} />
+            </div>
+          )
+        }
+      }
+
+      @connect((state, parentProps) => {
+        childMapStateInvokes++
+        // The state from parent props should always be consistent with the current state
+        expect(state).toEqual(parentProps.parentState)
+        return {}
+      })
+      class ChildContainer extends Component {
+        render() {
+          return <div />
+        }
+      }
+
+      const tree = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <SubProvider subState="string">
+            <Container />
+          </SubProvider>
+        </Provider>
+      )
+
+      expect(childMapStateInvokes).toBe(1)
+
+      // The store state stays consistent when setState calls are batched
+      store.dispatch({ type: 'APPEND', body: 'c' })
+      expect(childMapStateInvokes).toBe(2)
+
+      // setState calls DOM handlers are batched
+      const container = TestUtils.findRenderedComponentWithType(tree, Container)
+      const node = container.getWrappedInstance().refs.button
+      TestUtils.Simulate.click(node)
+      expect(childMapStateInvokes).toBe(3)
+
+      // Provider uses unstable_batchedUpdates() under the hood
+      store.dispatch({ type: 'APPEND', body: 'd' })
+      expect(childMapStateInvokes).toBe(4)
+    })
+  })
+})

--- a/test/components/combine.spec.js
+++ b/test/components/combine.spec.js
@@ -1,0 +1,78 @@
+/*eslint-disable react/prop-types*/
+
+import expect from 'expect'
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+import { combineReducers, createStore } from 'redux'
+import { Provider, SubProvider, combineConnected, connect } from '../../src/index'
+
+describe('React', () => {
+  describe('combineConnected', () => {
+    it('should create SubProviders with the given subStates', () => {
+      const reducer = (state = 0, action) => {
+        return (action === "INC") ? state + 1 : state;
+      }
+      const mapStateToProps = expect.createSpy().andCall(state => ({ count: state }))
+
+      @connect(mapStateToProps)
+      class Counter extends React.Component {
+        render() {
+          return <div>{ this.props.count }</div>
+        }
+      }
+
+      const store = createStore(combineReducers({
+        counter: reducer
+      }));
+
+      let { counter: MyCounter } = combineConnected({
+        counter: Counter
+      });
+
+      let tree;
+      expect(() => {
+        tree = TestUtils.renderIntoDocument(
+          <Provider store={store}>
+            <MyCounter />
+          </Provider>
+          )
+      }).toNotThrow()
+      const subprovider = TestUtils.findRenderedComponentWithType(tree, SubProvider)
+      expect(subprovider).toExist();
+
+      expect(mapStateToProps).toHaveBeenCalledWith(0, {});
+    })
+
+    it('should return components under the correct keys', () => {
+      @connect()
+      class Child extends React.Component {
+        render() {
+          return <div />
+        }
+      }
+
+      let { child: Child1 } = combineConnected({
+        child: Child
+      });
+
+      expect(Child1).toExist();
+
+      let { child: Child2, Child3 } = combineConnected({
+        child: { Child3: Child }
+      });
+
+      expect(Child2).toNotExist();
+      expect(Child3).toExist();
+
+      let Child4 = Child;
+      expect(Child4).toEqual(Child);
+
+      ({ Child4 } = combineConnected({
+        child: { Child4 }
+      }));
+
+      expect(Child4).toExist();
+      expect(Child4).toNotEqual(Child);
+    })
+  })
+})


### PR DESCRIPTION
Implements #617 

This PR allows you to combine `connect()`ed components in a similar way to `combineReducers()`, so that their `mapStateToProps` function only receives the section of the state tree relevant to them rather than the whole thing. 

This aids reusability as components do not need to know where in the state tree they appear. It should also help performance as mapStateToProps will only be called when the subtree is changed, not the global state.

This is achieved with a `SubProvider` component which provides a proxy store in its child context. The proxy store passes `dispatch()` and `subscribe()` through to the real store but intercepts `getState()` and only returns the property of the state object specified by the `SubProvider`'s `subState` prop.

You don't need to use SubProvider directly as there is also `combineConnected()` which takes an object containing `connnect()`ed components and returns them wrapped in SubProviders, eg:

```js
let { child1: Child1, child2: Child2 } = combineConnected({
  child1: Component1,
  child2: Component2
});

<Provider store={store}>
  <div>
    <Child1 />
    <Child2 />
  </div>
</Provider>
```

`mapStateToProps` on `Child1` will only receive `state.child1`, and `mapStateToProps` on `Child2` will only receive `state.child2`.

See example:
https://gist.github.com/simlrh/2212d5e2ae274839249618af5537dcfb

Documentation and tests have been added.

I know I didn't wait to find out if you actually want this feature, but I was going to do it anyway for my own education and use :)
