### PR TITLE
Fix the problem introduced by previous refactor in `shallowEqual`

### DIFF
--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -7,8 +7,10 @@ export default function shallowEqual(a, b) {
   let countB = 0
   
   for (let key in a) {
-    if (hasOwn.call(a, key) && a[key] !== b[key]) return false
-    countA++
+    if (hasOwn.call(a, key)) {
+      if (a[key] !== b[key]) return false
+      countA++
+    }
   }
 
   for (let key in b) {


### PR DESCRIPTION
Previous refactor `shallowEqual` has introduced an issue as follow
```
function A() {}
A.prototype.a = 1
const a = new A()
const b = { a: 2 }
shallowEqual(a, b) // returns true, expects false
```