### PR TITLE
Duck-type subscription in prop checks

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,6 +1,5 @@
 import { Component, PropTypes, Children } from 'react'
-import Subscription from '../utils/Subscription'
-import storeShape from '../utils/storeShape'
+import { storeShape, subscriptionShape } from '../utils/PropTypes'
 import warning from '../utils/warning'
 
 let didWarnAboutReceivingStore = false
@@ -51,6 +50,6 @@ Provider.propTypes = {
 }
 Provider.childContextTypes = {
   store: storeShape.isRequired,
-  storeSubscription: PropTypes.instanceOf(Subscription)
+  storeSubscription: subscriptionShape
 }
 Provider.displayName = 'Provider'

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -9,6 +9,13 @@ let hotReloadingVersion = 0
 const dummyState = {}
 function noop() {}
 
+const subscriptionShape = PropTypes.shape({
+  trySubscribe: PropTypes.func.isRequired,
+  tryUnsubscribe: PropTypes.func.isRequired,
+  notifyNestedSubs: PropTypes.func.isRequired,
+  isSubscribed: PropTypes.func.isRequired,
+})
+
 function makeSelectorStateful(sourceSelector, store) {
   // wrap the selector in an object that tracks its results between runs.
   const selector = {
@@ -81,10 +88,10 @@ export default function connectAdvanced(
 
   const contextTypes = {
     [storeKey]: storeShape,
-    [subscriptionKey]: PropTypes.instanceOf(Subscription),
+    [subscriptionKey]: subscriptionShape,
   }
   const childContextTypes = {
-    [subscriptionKey]: PropTypes.instanceOf(Subscription)
+    [subscriptionKey]: subscriptionShape,
   }
 
   return function wrapWithConnect(WrappedComponent) {

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -1,21 +1,13 @@
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react'
 
 import Subscription from '../utils/Subscription'
-import storeShape from '../utils/storeShape'
+import { storeShape, subscriptionShape } from '../utils/PropTypes'
 
 let hotReloadingVersion = 0
 const dummyState = {}
 function noop() {}
-
-const subscriptionShape = PropTypes.shape({
-  trySubscribe: PropTypes.func.isRequired,
-  tryUnsubscribe: PropTypes.func.isRequired,
-  notifyNestedSubs: PropTypes.func.isRequired,
-  isSubscribed: PropTypes.func.isRequired,
-})
-
 function makeSelectorStateful(sourceSelector, store) {
   // wrap the selector in an object that tracks its results between runs.
   const selector = {
@@ -201,16 +193,16 @@ export default function connectAdvanced(
 
       initSubscription() {
         if (!shouldHandleStateChanges) return
-        
+
         // parentSub's source should match where store came from: props vs. context. A component
         // connected to the store via props shouldn't use subscription from context, or vice versa.
         const parentSub = (this.propsMode ? this.props : this.context)[subscriptionKey]
         this.subscription = new Subscription(this.store, parentSub, this.onStateChange.bind(this))
-        
+
         // `notifyNestedSubs` is duplicated to handle the case where the component is  unmounted in
         // the middle of the notification loop, where `this.subscription` will then be null. An
         // extra null check every change can be avoided by copying the method onto `this` and then
-        // replacing it with a no-op on unmount. This can probably be avoided if Subscription's 
+        // replacing it with a no-op on unmount. This can probably be avoided if Subscription's
         // listeners logic is changed to not call listeners that have been unsubscribed in the
         // middle of the notification loop.
         this.notifyNestedSubs = this.subscription.notifyNestedSubs.bind(this.subscription)
@@ -225,7 +217,7 @@ export default function connectAdvanced(
           this.componentDidUpdate = this.notifyNestedSubsOnComponentDidUpdate
           this.setState(dummyState)
         }
-      }      
+      }
 
       notifyNestedSubsOnComponentDidUpdate() {
         // `componentDidUpdate` is conditionally implemented when `onStateChange` determines it

--- a/src/utils/PropTypes.js
+++ b/src/utils/PropTypes.js
@@ -1,0 +1,14 @@
+import { PropTypes } from 'react'
+
+export const subscriptionShape = PropTypes.shape({
+  trySubscribe: PropTypes.func.isRequired,
+  tryUnsubscribe: PropTypes.func.isRequired,
+  notifyNestedSubs: PropTypes.func.isRequired,
+  isSubscribed: PropTypes.func.isRequired,
+})
+
+export const storeShape = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired
+})

--- a/src/utils/storeShape.js
+++ b/src/utils/storeShape.js
@@ -1,7 +1,0 @@
-import { PropTypes } from 'react'
-
-export default PropTypes.shape({
-  subscribe: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
-  getState: PropTypes.func.isRequired
-})


### PR DESCRIPTION
Use `PropTypes.shape` instead of instanceOf checks which don't work across multiple instances of react-redux. Granted it's not a problem that _should_ occur since they should be deduped, but dependency management is hard, and sometimes that's not feasible due to symlinks and the like. This is (I think) more idiomatic JS anyway :)

thanks! (sorry if something obvious is off i wrote this in the GH editor)