### PR TITLE
Add React 16 as a valid peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "loose-envify": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0",
+    "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
     "redux": "^2.0.0 || ^3.0.0"
   },
   "browserify": {


### PR DESCRIPTION
We need this since we recently synced React 16 alpha changes to React Native.