### PR TITLE
Fix deprecation warnings for react >= 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "invariant": "^2.0.0",
     "lodash": "^4.2.0",
     "lodash-es": "^4.2.0",
-    "loose-envify": "^1.1.0"
+    "loose-envify": "^1.1.0",
+    "prop-types": "^15.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
 import warning from '../utils/warning'
 

--- a/src/utils/PropTypes.js
+++ b/src/utils/PropTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 export const subscriptionShape = PropTypes.shape({
   trySubscribe: PropTypes.func.isRequired,


### PR DESCRIPTION
Migrate `React.PropTypes` to `PropTypes` from the `prop-types` package, regarding the latest `react` version -> https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes