### PR TITLE
fixes React.PropTypes deprecation in React

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,19 +88,21 @@
     "jsdom": "^9.8.3",
     "mocha": "^3.2.0",
     "nyc": "^10.0.0",
-    "react": "^15.0.0",
+    "react": "^15.5.3",
     "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react-dom": "^15.5.3",
     "redux": "^3.0.0",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.1",
     "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.0.0",
     "lodash": "^4.2.0",
     "lodash-es": "^4.2.0",
-    "loose-envify": "^1.1.0"
+    "loose-envify": "^1.1.0",
+    "prop-types": "^15.5.4"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,6 +1,7 @@
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
 import warning from '../utils/warning'
+import {PropTypes} from 'prop-types'
 
 let didWarnAboutReceivingStore = false
 function warnAboutReceivingStore() {

--- a/src/utils/PropTypes.js
+++ b/src/utils/PropTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import { PropTypes } from 'prop-types'
 
 export const subscriptionShape = PropTypes.shape({
   trySubscribe: PropTypes.func.isRequired,

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,10 +1,11 @@
 /*eslint-disable react/prop-types*/
 
 import expect from 'expect'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
 import { Provider, connect } from '../../src/index'
+import {PropTypes} from 'prop-types'
 
 describe('React', () => {
   describe('Provider', () => {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,11 +1,12 @@
 /*eslint-disable react/prop-types*/
 
 import expect from 'expect'
-import React, { createClass, Children, PropTypes, Component } from 'react'
+import React, { createClass, Children, Component } from 'react'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
 import { connect } from '../../src/index'
+import {PropTypes} from 'prop-types'
 
 describe('React', () => {
   describe('connect', () => {
@@ -1567,7 +1568,7 @@ describe('React', () => {
       }
 
       ImpureComponent.contextTypes = {
-        statefulValue: React.PropTypes.number
+        statefulValue: PropTypes.number
       }
 
       const decorator = connect(state => state, null, null, { pure: false })
@@ -1591,7 +1592,7 @@ describe('React', () => {
       }
 
       StatefulWrapper.childContextTypes = {
-        statefulValue: React.PropTypes.number
+        statefulValue: PropTypes.number
       }
 
       const tree = TestUtils.renderIntoDocument(


### PR DESCRIPTION
This partially fixes [deprecation issues](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) related to PropTypes that causes warnings to pop up when using react-redux with version 15.5 of React. This passes tests.

In the react-redux test setups, there are still issues with createClass and TestUtils that need to be fixed but I haven't been able to understand the test structuring well enough to fix them.  

Fixes #664 