### PR TITLE
[4.x] Fix deprecation warnings for react >= 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,8 @@
     "istanbul": "^0.3.17",
     "jsdom": "~5.4.3",
     "mocha": "^2.2.5",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
     "redux": "^3.0.0",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "webpack": "^1.11.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.1",
     "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.0.0",
     "lodash": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "hoist-non-react-statics": "^1.0.3",
     "invariant": "^2.0.0",
     "lodash": "^4.2.0",
-    "loose-envify": "^1.1.0"
+    "loose-envify": "^1.1.0",
+    "prop-types": "^15.5.4"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^15.4.0-0 || ^16.0.0-0",

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 import storeShape from '../utils/storeShape'
 import warning from '../utils/warning'
 

--- a/src/utils/storeShape.js
+++ b/src/utils/storeShape.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 export default PropTypes.shape({
   subscribe: PropTypes.func.isRequired,

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,5 +1,6 @@
 import expect from 'expect'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
 import { Provider } from '../../src/index'

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import { createStore } from 'redux'
 import { Provider } from '../../src/index'
 
@@ -35,14 +35,14 @@ describe('React', () => {
         expect(() => TestUtils.renderIntoDocument(
           <Provider store={store}>
           </Provider>
-        )).toThrow(/exactly one child/)
+        )).toThrow(/a single React element/)
 
         expect(() => TestUtils.renderIntoDocument(
           <Provider store={store}>
             <div />
             <div />
           </Provider>
-        )).toThrow(/exactly one child/)
+        )).toThrow(/a single React element/)
       } finally {
         Provider.propTypes = propTypes
       }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,5 +1,6 @@
 import expect from 'expect'
-import React, { createClass, Children, PropTypes, Component } from 'react'
+import React, { createClass, Children, Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'
 import { createStore } from 'redux'
@@ -1381,7 +1382,7 @@ describe('React', () => {
       }
 
       ImpureComponent.contextTypes = {
-        statefulValue: React.PropTypes.number
+        statefulValue: PropTypes.number
       }
 
       const decorator = connect(state => state, null, null, { pure: false })
@@ -1405,7 +1406,7 @@ describe('React', () => {
       }
 
       StatefulWrapper.childContextTypes = {
-        statefulValue: React.PropTypes.number
+        statefulValue: PropTypes.number
       }
 
       const tree = TestUtils.renderIntoDocument(

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -3,7 +3,7 @@ import React, { Children, Component } from 'react'
 import createClass from 'create-react-class'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import { createStore } from 'redux'
 import { connect } from '../../src/index'
 
@@ -11,7 +11,7 @@ describe('React', () => {
   describe('connect', () => {
     class Passthrough extends Component {
       render() {
-        return <div {...this.props} />
+        return <div />
       }
     }
 
@@ -1729,7 +1729,7 @@ describe('React', () => {
           updatedCount++
         }
         render() {
-          return <div {...this.props} />
+          return <div />
         }
       }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1,5 +1,6 @@
 import expect from 'expect'
-import React, { createClass, Children, Component } from 'react'
+import React, { Children, Component } from 'react'
+import createClass from 'create-react-class'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-addons-test-utils'


### PR DESCRIPTION
Follow-up of #663, I backported the patch for new deprecation warnings introduced by react 15.5.0

`react-addons-test-utils` seems to have been moved to `react-dom/test-utils` only on `react >= 15.5.0`, in order to use it we'll have to bump the devDependencies to at least that version.

As it's used only during test phase, I don't think it will be that much of a problem, what do you think?