### PR TITLE
Remove state between connectAdvanced calls in example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -361,7 +361,6 @@ import * as actionCreators from './actionCreators'
 import { bindActionCreators } from 'redux'
 
 function selectorFactory(dispatch) {
-  let state = {}
   let ownProps = {}
   let result = {}
   const actions = bindActionCreators(actionCreators, dispatch)
@@ -369,7 +368,6 @@ function selectorFactory(dispatch) {
   return (nextState, nextOwnProps) => {
     const todos = nextState.todos[nextProps.userId]
     const nextResult = { ...nextOwnProps, todos, addTodo }
-    state = nextState
     ownProps = nextOwnProps
     if (!shallowEqual(result, nextResult)) result = nextResult
     return result


### PR DESCRIPTION
When I saw this example I was initially excited by the prospect of storing `state` between `connectAdvanced` calls.

I thought of the uses like storing the deleted todo items, or even just the count. But then it dawned on me that the idiomatic approach to Redux, such as the ability for time travel - is challenged when the previous state is stored. For example if I stored `deletedTodoCount` and then used time travel this figure would be wrong because the previous state would be from the future.

For newbies like myself, suggesting this in documentation can be misleading and might encourage the wrong practice of depending on the difference between states for props when really should come from the store.