### PR TITLE
Persist Nested Subscriptions Through Hot Reload

### DIFF
--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -24,6 +24,10 @@ function createListenerCollection() {
       }
     },
 
+    get() {
+      return next
+    },
+
     subscribe(listener) {
       let isSubscribed = true
       if (next === current) next = current.slice()


### PR DESCRIPTION
This resolves #670.
This likely also resolves #636 but I encounter errors installing the linked repo on my machine.

## Cause Of Issue
When a connected component hot reloads, it unsubscribes and then resubscribes to store updates. As part of unsubscription, all child listeners (also referred to as `nestedSubs`) are removed. For child components that also hot-reload, this is fine, as they will resubscribe during the hot reload. However, if any of the hot reloading parent's descendants are connected but do **not** hot reload, they are never resubscribed to store updates.

## Solution
To resolve this, we persist the previous component's listeners to the reloaded version of the component, so that descendants that did not reload are still subscribed properly to store updates.

## Downsides
This does mean that the old versions of hot reloaded components are still subscribed, but when they unmount as part of the reload, their `selector.shouldComponentUpdate`, `selector.run`, and `notifyNestedSubs` are all set to no-ops, making their `onStateChange` always a no-op itself.