### PR TITLE
add "Caveat" section to readme noting how you can't dispatch during `componentWillMount` on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ If you are on an older version of React Native, you’ll need to keep using [Rea
 We do a deep dive on how React Redux works in [this readthesource episode](https://www.youtube.com/watch?v=VJ38wSFbM3A).  
 Enjoy!
 
+## Caveat
+
+If you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach to SSR is to use a routing mechanism based on the URL to dispatch all the necessary actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`.
+
+You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven pre-hydration on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Enjoy!
 
 ## Caveat
 
-While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions in response to user-triggered events, and during SSR to use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
+While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions in response to user-triggered events. During SSR use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
 
 You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven pre-hydration on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Enjoy!
 
 ## Caveat
 
-While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions before your first or in response to user-triggered events. During SSR use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
+While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach to cover all environments is to only dispatch actions before your first render or in response to user-triggered events. During SSR use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
 
 You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven *pre-hydration* on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Enjoy!
 
 ## Caveat
 
-If you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach to SSR is to use a routing mechanism based on the URL to dispatch all the necessary actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`.
+If you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach to SSR is to use a routing mechanism based on the URL to dispatch all the necessary actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
 
 You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven pre-hydration on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Enjoy!
 
 ## Caveat
 
-While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions in response to user-triggered events. During SSR use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
+While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions before your first or in response to user-triggered events. During SSR use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
 
-You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven pre-hydration on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
+You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven *pre-hydration* on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Enjoy!
 
 ## Caveat
 
-If you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach to SSR is to use a routing mechanism based on the URL to dispatch all the necessary actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
+While peforming server-side rendering, if you dispatch actions during `componentWillMount` the resulting state will not render in the wrapped component, nor in parents or sibblings. The idiomatic approach is to only dispatch actions in response to user-triggered events, and during SSR to use a routing mechanism based on the URL to dispatch actions on the store (and `await` on them if necessary) ***before*** calling `ReactDOMServer.renderTostring`. This is called "server-side pre-hydration."
 
 You may want to checkout [Redux First Router](https://github.com/faceyspacey/redux-first-router) for a Redux-specific routing package that helps you resolve URL-driven pre-hydration on the server. Check the `thunk` option in their [server-rendering docs](https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md).
 


### PR DESCRIPTION
NOTE: I would have recommended other packages as well, but there are no popular Redux-specific routing packages other than [Redux First Router](https://medium.com/@faceyspacey/pre-release-redux-first-router-a-step-beyond-redux-little-router-cd2716576aea) that offer server-side data-fetching or route-based data-fetching in general. For example the most popular Redux-specific routing package, *Redux Little Router*, does not have data-fetching built in. Which means many users might still end up using `componentWillMount` while using it.

In the future, a short list should be amended here :)