### PR TITLE
Move ref context binding to fix object freezing middleware

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -121,7 +121,6 @@ export default function connectAdvanced(
         this.renderCount = 0
         this.store = props[storeKey] || context[storeKey]
         this.propsMode = Boolean(props[storeKey])
-        this.setWrappedInstance = this.setWrappedInstance.bind(this)
 
         invariant(this.store,
           `Could not find "${storeKey}" in either the context or props of ` +
@@ -240,7 +239,7 @@ export default function connectAdvanced(
         // instance. a singleton memoized selector would then be holding a reference to the
         // instance, preventing the instance from being garbage collected, and that would be bad
         const withExtras = { ...props }
-        if (withRef) withExtras.ref = this.setWrappedInstance
+        if (withRef) withExtras.ref = this.setWrappedInstance.bind(this)
         if (renderCountProp) withExtras[renderCountProp] = this.renderCount++
         if (this.propsMode && this.subscription) withExtras[subscriptionKey] = this.subscription
         return withExtras


### PR DESCRIPTION
Closes #708 

Middleware that uses `Object.freeze` such as [redux-freeze](https://github.com/buunguyen/redux-freeze) started throwing an error somewhere between versions 5.0.0...5.0.5:

```
Uncaught TypeError: Cannot assign to read only property 'setWrappedInstance' of object '#<Connect>'
```

This is because `Connect` instances are being mutated here: https://github.com/reactjs/react-redux/blob/2726c59fa1e5929659067df2088c7c6e0d736f3a/src/components/connectAdvanced.js#L124

This PR moves the context binding of the ref function to a lazy assignment and doesn't mutate the original function.  IMO the intention of the code is clearer this way as well.