### PR TITLE
Remove `src` directory from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "files": [
     "dist",
     "lib",
-    "src",
     "es"
   ],
   "keywords": [


### PR DESCRIPTION
`./src` directory is not used in npm package, only `./es` (as source for ES-module), `./lib` (as a source for old js syntax module) and `./dist` (as UMD module), so it can be removed. It reduces size of installed `react-redux` module by 21%