### PR TITLE
Update hoist-non-react-statics to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "rollup-plugin-uglify": "^2.0.1"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.3",
+    "hoist-non-react-statics": "^2.2.1",
     "invariant": "^2.0.0",
     "lodash": "^4.2.0",
     "lodash-es": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,9 +1580,9 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.2.1.tgz#a7e41c760121d0abfc7a2339b331d29a26389e52"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
https://github.com/mridgway/hoist-non-react-statics/releases/tag/v2.0.0