### PR TITLE
feat(connect): return false to skip update

### DIFF
--- a/src/connect/mergeProps.js
+++ b/src/connect/mergeProps.js
@@ -23,7 +23,7 @@ export function wrapMergePropsFunc(mergeProps) {
         mergedProps = nextMergedProps
 
         if (process.env.NODE_ENV !== 'production')
-          verifyPlainObject(mergedProps, displayName, 'mergeProps')
+          mergedProps === false || verifyPlainObject(mergedProps, displayName, 'mergeProps')
       }
 
       return mergedProps

--- a/src/connect/wrapMapToProps.js
+++ b/src/connect/wrapMapToProps.js
@@ -57,8 +57,8 @@ export function wrapMapToPropsFunc(mapToProps, methodName) {
         props = proxy(stateOrDispatch, ownProps)
       }
 
-      if (process.env.NODE_ENV !== 'production') 
-        verifyPlainObject(props, displayName, methodName)
+      if (process.env.NODE_ENV !== 'production')
+        props === false || verifyPlainObject(props, displayName, methodName)
 
       return props
     }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2041,6 +2041,324 @@ describe('React', () => {
       expect(memoizedReturnCount).toBe(2)
     })
 
+    it('should not update when mapStateToProps without ownProps returns false', () => {
+      let updatedCount = 0
+      const store = createStore(({ value = 0 } = { value: 0 }, action) => ({
+        value: action.type === 'test' ? value + 1 : value
+      }))
+
+      const mapStateFactory = state => {
+        if (state.value > 2) return false
+        return { value: state.value }
+      }
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        componentWillUpdate() {
+          updatedCount++
+        }
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="a" />
+          </div>
+        </ProviderMock>
+      )
+
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(1)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+    })
+
+    it('should not update when mapStateToProps with ownProps returns false', () => {
+      let updatedCount = 0
+      const store = createStore(({ value = 0 } = { value: 0 }, action) => ({
+        value: action.type === 'test' ? value + 1 : value
+      }))
+
+      /*eslint-disable no-unused-vars */
+      const mapStateFactory = (state, ownProps) => {
+        if (state.value > 2) return false
+        return { value: state.value }
+      }
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        componentWillUpdate() {
+          updatedCount++
+        }
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="a" />
+          </div>
+        </ProviderMock>
+      )
+
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(1)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+    })
+
+    it('should throw if initial mapStateToProps without ownProps returns false', () => {
+      const store = createStore(() => ({ value: 1}))
+
+      /*eslint-disable no-unused-vars */
+      const mapStateFactory = state => false
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      expect(() =>
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <div>
+              <Container name="a" />
+            </div>
+          </ProviderMock>
+        )
+      ).toThrow(
+        /Cannot short-circuit initial call to mapStateToProps/
+      )
+    })
+
+    it('should throw if initial mapStateToProps with ownProps returns false', () => {
+      const store = createStore(() => ({ value: 1}))
+
+      /*eslint-disable no-unused-vars */
+      const mapStateFactory = (state, ownProps) => false
+
+      @connect(mapStateFactory)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      expect(() =>
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <div>
+              <Container name="a" />
+            </div>
+          </ProviderMock>
+        )
+      ).toThrow(
+        /Cannot short-circuit initial call to mapStateToProps/
+      )
+    })
+
+    it('should not update when mapDispatchToProps with ownProps returns false', () => {
+      let updatedCount = 0
+      let mappedDispatchCount = 0
+      const store = createStore(({ value = 0 } = { value: 0 }, action) => ({
+        value: action.type === 'test' ? value + 1 : value
+      }))
+
+      const mapDispatchFactory = (dispatch, ownProps) => {
+        if (ownProps.value > 2) return false
+        mappedDispatchCount++
+        return { myAction: () => {} }
+      }
+
+      @connect(null, mapDispatchFactory)
+      class Container extends Component {
+        componentWillUpdate() {
+          updatedCount++
+        }
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const mapStateFactory = state => {
+        if (state.value > 3) return false
+        return { value: state.value }
+      }
+
+      @connect(mapStateFactory, mapDispatchFactory)
+      class Wrapper extends Component {
+        render() {
+          return <Container {...this.props} own={Math.random()} />
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Wrapper name="a" />
+          </div>
+        </ProviderMock>
+      )
+
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(1)
+      expect(mappedDispatchCount).toBe(3)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+      expect(mappedDispatchCount).toBe(4)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(3)
+      expect(mappedDispatchCount).toBe(4)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(3)
+      expect(mappedDispatchCount).toBe(4)
+    })
+
+    it('should throw if initial mapDispatchToProps without ownProps returns false', () => {
+      const store = createStore(() => ({ value: 1}))
+
+      /*eslint-disable no-unused-vars */
+      const mapDispatchFactory = state => false
+
+      @connect(null, mapDispatchFactory)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      expect(() =>
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <div>
+              <Container name="a" />
+            </div>
+          </ProviderMock>
+        )
+      ).toThrow(
+        /Cannot short-circuit initial call to mapDispatchToProps/
+      )
+    })
+
+    it('should throw if initial mapDispatchToProps with ownProps returns false', () => {
+      const store = createStore(() => ({ value: 1}))
+
+      /*eslint-disable no-unused-vars */
+      const mapDispatchFactory = (state, ownProps) => false
+
+      @connect(null, mapDispatchFactory)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      expect(() =>
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <div>
+              <Container name="a" />
+            </div>
+          </ProviderMock>
+        )
+      ).toThrow(
+        /Cannot short-circuit initial call to mapDispatchToProps/
+      )
+    })
+
+    it('should not update when mergeProps returns false', () => {
+      let updatedCount = 0
+      let mergedPropsCount = 0
+      const store = createStore(({ value = 0 } = { value: 0 }, action) => ({
+        value: action.type === 'test' ? value + 1 : value
+      }))
+
+      const mapStateFactory = state => ({ value: state.value })
+
+      /*eslint-disable no-unused-vars */
+      const mapDispatchFactory = dispatch => ({ myAction: () => {} })
+
+      const mergeProps = (stateProps, dispatchProps, ownProps) => {
+        if (stateProps.value > 2) return false
+        mergedPropsCount++
+        return {
+          ...stateProps,
+          ...dispatchProps,
+          ...ownProps
+        }
+      }
+
+      @connect(mapStateFactory, mapDispatchFactory, mergeProps)
+      class Container extends Component {
+        componentWillUpdate() {
+          updatedCount++
+        }
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <div>
+            <Container name="a" />
+          </div>
+        </ProviderMock>
+      )
+
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(1)
+      expect(mergedPropsCount).toBe(2)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+      expect(mergedPropsCount).toBe(3)
+      store.dispatch({ type: 'test' })
+      expect(updatedCount).toBe(2)
+      expect(mergedPropsCount).toBe(3)
+    })
+
+    it('should throw if initial mergeProps returns false', () => {
+      const store = createStore(() => ({ value: 1}))
+
+      const mapStateFactory = state => ({ value: state.value })
+
+      /*eslint-disable no-unused-vars */
+      const mapDispatchFactory = dispatch => ({ myAction: () => {} })
+
+      /*eslint-disable no-unused-vars */
+      const mergeProps = (stateProps, dispatchProps, ownProps) => false
+
+      @connect(mapStateFactory, mapDispatchFactory, mergeProps)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      expect(() =>
+        TestUtils.renderIntoDocument(
+          <ProviderMock store={store}>
+            <div>
+              <Container name="a" />
+            </div>
+          </ProviderMock>
+        )
+      ).toThrow(
+        /Cannot short-circuit initial call to mergeProps/
+      )
+    })
+
     it('should not call update if mergeProps return value has not changed', () => {
       let mapStateCalls = 0
       let renderCalls = 0


### PR DESCRIPTION
This adds a new feature allowing us to short-circuit `mapStateToProps`, `mapDispatchToProps`, and `mergeProps` functions by returning `false` to fallback to existing/previous props.

The motivation here is performance optimization. Because these functions may be called with every change to Redux state or own props, they can have a negative impact on performance. Though we can use something like `reselect` memoization, it has implications for memory consumption, an overheard that may not be desired.

In certain cases, we may be able to quickly determine upfront if anything relevant has changed or if the state has any data to which the component needs to respond, and if not, then there's no need to continue computing the props mapping. This is analogous to a React component's `shouldComponentUpdate` lifecycle hook.

Here's an example. Suppose we have a UI that renders cards that can update with real-time data. But it allows cards to be paused, either manually or due to being in the background (minimized, zoomed out, off-screen, etc.). If a card is paused, then we don't need it to update in real-time. With this new feature, we can now detect if `card.paused` is `true`, and if so `return false` to indicate that it can just use previous props, rather than to waste resources going on to call `get` for potentially many extracted fields (or in other ways non-trivially transform the data):

```js
import get from 'lodash/get'

const mapStateToProps = (state, ownProps) => {
  const card = state.cards[ownProps.cardId]

  if (card && card.paused) return false

  return {
    title: get(card, 'titles.full'),
    hasFacebookButton: get(card, 'shareButtons.facebook.isEnabled'),
    // ...
  }
}
```

Here's another example:

```js
import get from 'lodash/get'

const mapStateToProps = state => {
  const product = get(state, 'products.product')

  return {
    title: get(product, 'displayName.full'),
    price: get(product, 'priceData.usd.afterTax'),
    // ...
  }
}
```

Above, if `state.products.product` is `undefined`, it's a waste of time to go on to call `get` for potentially many extracted fields, since we know all of those will also return `undefined`, or to in other ways non-trivially transform the data.

With this new feature, we can now do this:

```js
import get from 'lodash/get'

const mapStateToProps = state => {
  const product = get(state, 'products.product')

  if (!product) return false

  return {
    title: get(product, 'displayName.full'),
    price: get(product, 'priceData.usd.afterTax'),
    // ...
  }
}
```

Now nothing below the `return false` will be executed, and the component will use its previous values for any props.

Ignore the workaround of returning `{}` early here - that may not work for less trivial examples, e.g., where two possibly-`undefined` objects are selected from the state, without introducing more complex branching logic and object merging.

This example may be a bit contrived, since in a real-world scenario in most cases you probably wouldn't want to retain stale data in props from a previous product if the product data were ever deleted from the state. But if you know your app never deletes product data once defined, then this would increase performance for all the action dispatches until the product was defined.

