### PR TITLE
Add TypeScript typings corresponding to redux@next

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,295 @@
+import {
+  Component,
+  ComponentClass,
+  ComponentType,
+  ReactNode,
+  StatelessComponent,
+} from 'react'
+
+import {
+  Action,
+  Store,
+  Dispatch,
+  ActionCreator,
+} from 'redux'
+
+// Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+export interface DispatchProp<S> {
+  dispatch?: Dispatch<S>;
+}
+
+interface AdvancedComponentDecorator<TProps, TOwnProps> {
+    (component: ComponentType<TProps>): ComponentClass<TOwnProps>;
+}
+
+// Injects props and removes them from the prop requirements.
+// Will not pass through the injected props if they are passed in during
+// render. Also adds new prop requirements from TNeedsProps.
+export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
+    <P extends TInjectedProps>(
+        component: ComponentType<P>
+    ): ComponentClass<Omit<P, keyof TInjectedProps> & TNeedsProps> & {WrappedComponent: Component<P>}
+}
+
+// Injects props and removes them from the prop requirements.
+// Will not pass through the injected props if they are passed in during
+// render.
+export type InferableComponentEnhancer<TInjectedProps> =
+    InferableComponentEnhancerWithProps<TInjectedProps, {}>
+
+/**
+ * Connects a React component to a Redux store.
+ *
+ * - Without arguments, just wraps the component, without changing the behavior / props
+ *
+ * - If 2 params are passed (3rd param, mergeProps, is skipped), default behavior
+ * is to override ownProps (as stated in the docs), so what remains is everything that's
+ * not a state or dispatch prop
+ *
+ * - When 3rd param is passed, we don't know if ownProps propagate and whether they
+ * should be valid component props, because it depends on mergeProps implementation.
+ * As such, it is the user's responsibility to extend ownProps interface from state or
+ * dispatch props or both when applicable
+ *
+ * @param mapStateToProps
+ * @param mapDispatchToProps
+ * @param mergeProps
+ * @param options
+ */
+export interface Connect {
+    (): InferableComponentEnhancer<DispatchProp<any>>;
+
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
+    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any>, TOwnProps>;
+
+    <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+        mapStateToProps: null | undefined,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
+    ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
+
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
+    ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
+
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: null | undefined,
+        mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+
+    <no_state = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: null | undefined,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+
+    <no_state = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: null | undefined,
+        mapDispatchToProps: null | undefined,
+        mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+
+    <TStateProps = {}, no_dispatch = {}, TOwnProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: null | undefined,
+        mergeProps: null | undefined,
+        options: Options<TStateProps, TOwnProps>
+    ): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
+
+    <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+        mapStateToProps: null | undefined,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: null | undefined,
+        options: Options<no_state, TOwnProps>
+    ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
+
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: null | undefined,
+        options: Options<TStateProps, TOwnProps>
+    ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
+
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+        options: Options<TStateProps, TOwnProps, TMergedProps>
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+}
+
+/**
+ * The connect function. See {@type Connect} for details.
+ */
+export const connect: Connect;
+
+interface MapStateToProps<TStateProps, TOwnProps> {
+    (state: any, ownProps: TOwnProps): TStateProps;
+}
+
+interface MapStateToPropsFactory<TStateProps, TOwnProps> {
+    (initialState: any, ownProps: TOwnProps): MapStateToProps<TStateProps, TOwnProps>;
+}
+
+type MapStateToPropsParam<TStateProps, TOwnProps> = MapStateToPropsFactory<TStateProps, TOwnProps> | MapStateToProps<TStateProps, TOwnProps> | null | undefined;
+
+interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
+    (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps;
+}
+
+type MapDispatchToProps<TDispatchProps, TOwnProps> =
+    MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | TDispatchProps;
+
+interface MapDispatchToPropsFactory<TDispatchProps, TOwnProps> {
+    (dispatch: Dispatch<any>, ownProps: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
+}
+
+type MapDispatchToPropsParam<TDispatchProps, TOwnProps> = MapDispatchToPropsFactory<TDispatchProps, TOwnProps> | MapDispatchToProps<TDispatchProps, TOwnProps>;
+
+interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
+    (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
+}
+
+interface Options<TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
+    /**
+     * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
+     * preventing unnecessary updates, assuming that the component is a “pure” component
+     * and does not rely on any input or state other than its props and the selected Redux store’s state.
+     * Defaults to true.
+     * @default true
+     */
+    pure?: boolean;
+
+    /**
+     * When pure, compares incoming store state to its previous value.
+     * @default strictEqual
+     */
+    areStatesEqual?: (nextState: any, prevState: any) => boolean;
+
+    /**
+     * When pure, compares incoming props to its previous value.
+     * @default shallowEqual
+     */
+    areOwnPropsEqual?: (nextOwnProps: TOwnProps, prevOwnProps: TOwnProps) => boolean;
+
+    /**
+     * When pure, compares the result of mapStateToProps to its previous value.
+     * @default shallowEqual
+     */
+    areStatePropsEqual?: (nextStateProps: TStateProps, prevStateProps: TStateProps) => boolean;
+
+    /**
+     * When pure, compares the result of mergeProps to its previous value.
+     * @default shallowEqual
+     */
+    areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;
+}
+
+/**
+ * Connects a React component to a Redux store. It is the base for {@link connect} but is less opinionated about
+ * how to combine <code>state</code>, <code>props</code>, and <code>dispatch</code> into your final props. It makes no
+ * assumptions about defaults or memoization of results, leaving those responsibilities to the caller.It does not
+ * modify the component class passed to it; instead, it returns a new, connected component class for you to use.
+ *
+ * @param selectorFactory The selector factory. See {@type SelectorFactory} for details.
+ * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
+ *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
+ */
+export function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
+    selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
+    connectOptions?: ConnectOptions & TFactoryOptions
+): AdvancedComponentDecorator<TProps, TOwnProps>;
+
+/**
+ * Initializes a selector function (during each instance's constructor). That selector function is called any time the
+ * connector component needs to compute new props, as a result of a store state change or receiving new props. The
+ * result of <code>selector</code> is expected to be a plain object, which is passed as the props to the wrapped
+ * component. If a consecutive call to <code>selector</code> returns the same object (<code>===</code>) as its previous
+ * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
+ * previous object when appropriate.
+ */
+export interface SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> {
+    (dispatch: Dispatch<S>, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
+}
+
+export interface Selector<S, TProps, TOwnProps> {
+    (state: S, ownProps: TOwnProps): TProps
+}
+
+export interface ConnectOptions {
+    /**
+     * Computes the connector component's displayName property relative to that of the wrapped component. Usually
+     * overridden by wrapper functions.
+     *
+     * @default name => 'ConnectAdvanced('+name+')'
+     * @param componentName
+     */
+    getDisplayName?: (componentName: string) => string
+    /**
+     * Shown in error messages. Usually overridden by wrapper functions.
+     *
+     * @default 'connectAdvanced'
+     */
+    methodName?: string
+    /**
+     * If defined, a property named this value will be added to the props passed to the wrapped component. Its value
+     * will be the number of times the component has been rendered, which can be useful for tracking down unnecessary
+     * re-renders.
+     *
+     * @default undefined
+     */
+    renderCountProp?: string
+    /**
+     * Controls whether the connector component subscribes to redux store state changes. If set to false, it will only
+     * re-render on <code>componentWillReceiveProps</code>.
+     *
+     * @default true
+     */
+    shouldHandleStateChanges?: boolean
+    /**
+     * The key of props/context to get the store. You probably only need this if you are in the inadvisable position of
+     * having multiple stores.
+     *
+     * @default 'store'
+     */
+    storeKey?: string
+    /**
+     * If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+     *
+     * @default false
+     */
+    withRef?: boolean
+}
+
+export interface ProviderProps {
+    /**
+     * The single Redux store in your application.
+     */
+    store?: Store<any, any>;
+    children?: ReactNode;
+}
+
+/**
+ * Makes the Redux store available to the connect() calls in the component hierarchy below.
+ */
+export class Provider extends Component<ProviderProps> { }
+
+/**
+ * Creates a new <Provider> which will set the Redux Store on the passed key of the context. You probably only need this
+ * if you are in the inadvisable position of having multiple stores. You will also need to pass the same storeKey to the
+ * options argument of connect.
+ *
+ * @param storeKey The key of the context on which to set the store.
+ */
+export function createProvider(storeKey: string): typeof Provider;

--- a/index.d.ts
+++ b/index.d.ts
@@ -276,7 +276,7 @@ export interface ProviderProps {
     /**
      * The single Redux store in your application.
      */
-    store?: Store<any, any>;
+    store?: Store<any>;
     children?: ReactNode;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,8 +17,8 @@ import {
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
-export interface DispatchProp<S> {
-  dispatch?: Dispatch<S>;
+export interface DispatchProp {
+  dispatch?: Dispatch<{}>;
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {
@@ -60,11 +60,11 @@ export type InferableComponentEnhancer<TInjectedProps> =
  * @param options
  */
 export interface Connect {
-    (): InferableComponentEnhancer<DispatchProp<any>>;
+    (): InferableComponentEnhancer<DispatchProp>;
 
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
-    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any>, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
     <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,
@@ -105,7 +105,7 @@ export interface Connect {
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
         options: Options<TStateProps, TOwnProps>
-    ): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<DispatchProp & TStateProps, TOwnProps>;
 
     <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "homepage": "https://github.com/gaearon/react-redux",
   "devDependencies": {
+    "@types/react": "^16.0.18",
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-eslint": "^7.1.1",
@@ -99,7 +100,9 @@
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
-    "rollup-plugin-uglify": "^2.0.1"
+    "rollup-plugin-uglify": "^2.0.1",
+    "typescript": "^2.5.3",
+    "typescript-definition-tester": "^0.0.5"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "typings": "./index.d.ts",
   "scripts": {
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",

--- a/test/typescript.spec.js
+++ b/test/typescript.spec.js
@@ -1,0 +1,12 @@
+import * as tt from 'typescript-definition-tester'
+
+describe('TypeScript definitions', function () {
+  it('should compile against index.d.ts', (done) => {
+    tt.compileDirectory(
+      __dirname + '/typescript',
+      fileName => fileName.match(/\.tsx?$/),
+      { strict: true, jsx: true },
+      () => done()
+    )
+  })
+})

--- a/test/typescript.spec.js
+++ b/test/typescript.spec.js
@@ -1,6 +1,6 @@
 import * as tt from 'typescript-definition-tester'
 
-describe('TypeScript definitions', function () {
+describe('TypeScript definitions', () => {
   it('should compile against index.d.ts', (done) => {
     tt.compileDirectory(
       __dirname + '/typescript',
@@ -8,5 +8,5 @@ describe('TypeScript definitions', function () {
       { strict: true, jsx: true },
       () => done()
     )
-  })
+  }).timeout(5000)
 })

--- a/test/typescript/connect.tsx
+++ b/test/typescript/connect.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react'
+import { Dispatch, Reducer, createStore } from 'redux'
+import { Provider, connect } from '../..'
+
+type State = Todo[]
+
+interface Todo {
+  id: number
+  text: string
+  completed: boolean
+}
+
+type Action =
+  | { type: 'ADD_TODO'; text: string }
+  | { type: 'DELETE_TODO'; id: number }
+  | { type: 'EDIT_TODO'; id: number; text: string }
+  | { type: 'COMPLETE_TODO'; id: number }
+  | { type: 'COMPLETE_ALL' }
+  | { type: 'CLEAR_COMPLETED' }
+
+const initialState = [
+  {
+    text: 'Use Redux',
+    completed: false,
+    id: 0
+  }
+]
+
+const reducer = (state: State = initialState, action: Action) => {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return [
+        ...state,
+        {
+          id: state.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1,
+          completed: false,
+          text: action.text,
+        }
+      ]
+
+    case 'DELETE_TODO':
+      return state.filter(todo =>
+        todo.id !== action.id
+      )
+
+    case 'EDIT_TODO':
+      return state.map(todo =>
+        todo.id === action.id ?
+          { ...todo, text: action.text } :
+          todo
+      )
+
+    case 'COMPLETE_TODO':
+      return state.map(todo =>
+        todo.id === action.id ?
+          { ...todo, completed: !todo.completed } :
+          todo
+      )
+
+    case 'COMPLETE_ALL':
+      const areAllMarked = state.every(todo => todo.completed)
+      return state.map(todo => ({
+        ...todo,
+        completed: !areAllMarked
+      }))
+
+    case 'CLEAR_COMPLETED':
+      return state.filter(todo => todo.completed === false)
+
+    default:
+      return state
+  }
+}
+
+const store = createStore(reducer)
+
+interface AppProps extends State {
+  dispatch: Dispatch<Action>
+}
+
+const App = (props: AppProps) => <div />
+
+const ConnectedApp = connect(
+  (state: State) => state,
+  (dispatch: Dispatch<Action>) => ({ dispatch }),
+)(App)
+
+const providedApp = (
+  <Provider store={store}>
+    <ConnectedApp />
+  </Provider>
+)


### PR DESCRIPTION
Add built-in TypeScript typings copied from DefinitelyTyped but modified to accommodate upcoming revamped `redux` typings on the `next` branch (see [redux #2563](https://github.com/reactjs/redux/pull/2563)).