### PR TITLE
Remove extra comma after the last property in .eslintrc json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
     "ecmaFeatures": {
       "jsx": true,
       "experimentalObjectRestSpread": true
-    },
+    }
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
VS Code is showing error due to an extra comma after the last json property