### PR TITLE
Re-export compose from redux

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ import connectAdvanced from './components/connectAdvanced'
 import connect from './connect/connect'
 
 export { Provider, createProvider, connectAdvanced, connect }
+export { compose } from 'redux'


### PR DESCRIPTION
Most of the time, when  I want to use `connect` from `react-redux` package I don't have anything to import from the `redux` package. However, I find myself using `compose` most of the time I use `connect`. 

Re-exporting `compose` from `redux` package inside `react-redux` would allow reduce an extra import line.