### PR TITLE
Proposal for addition of a modifier of onStateChange

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -197,7 +197,11 @@ export default function connectAdvanced(
         // parentSub's source should match where store came from: props vs. context. A component
         // connected to the store via props shouldn't use subscription from context, or vice versa.
         const parentSub = (this.propsMode ? this.props : this.context)[subscriptionKey]
-        this.subscription = new Subscription(this.store, parentSub, this.onStateChange.bind(this))
+        let onStateChange = this.onStateChange.bind(this);
+        if (connectOptions.onStateChangeDecorator) {
+          onStateChange = connectOptions.onStateChangeDecorator(onStateChange)
+        }
+        this.subscription = new Subscription(this.store, parentSub, onStateChange)
 
         // `notifyNestedSubs` is duplicated to handle the case where the component is  unmounted in
         // the middle of the notification loop, where `this.subscription` will then be null. An


### PR DESCRIPTION
**Why**

i m working on a fairly complex application that heavily rely on react-redux combination.
Our mapStateToProps actually run some logic and also the components take their time to re renders.

When dispatching actions everything is fine.

When we dispatch a couple of actions in series, even if they interest 2 different part of the store or simply update something that will make a component change but in 2 different steps, the added overhead of a dispatch is noticeable

**How**

The solution we came with is to debounce the onStateChange of our root connected component with a lodash debounce ( 3 or 4 ms )

This allow dispatched fires in rapid sequence to fire just one onStateChange.

example:

```javascript
const myDebouncer = onStateChange => lodash.debounce(onStateChange, 4);
@connect(state => mapStateToProps, null, null, { onStateChangeDecorator: myDebouncer } )
export default class App extends Component { }
```

I understand this may seems an application need, but i also think is very usefull.
I did not find anyway to obtain this with the exposed options or with a different reduxMiddleware.

Your input on this matter is really appreciated as any help to achieve the same effect with a different solution