### PR TITLE
Fix test code coverage reporting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -24,7 +24,10 @@
   ],
   "env": {
     "test": {
-      "plugins": ["istanbul"]
+      "plugins": [
+        "istanbul",
+        ["transform-es2015-modules-commonjs", { "loose": true }]
+      ]
     },
     "commonjs": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf lib dist es coverage",
     "lint": "eslint src test",
     "prepare": "npm run clean && npm run build",
-    "test": "cross-env BABEL_ENV=commonjs NODE_ENV=test mocha --compilers js:babel-register --recursive --require ./test/setup.js",
+    "test": "cross-env BABEL_ENV=test NODE_ENV=test mocha --compilers js:babel-register --recursive --require ./test/setup.js",
     "test:watch": "npm test -- --watch",
     "test:cov": "cross-env NODE_ENV=test nyc npm test",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
@@ -118,7 +118,14 @@
     ]
   },
   "nyc": {
+    "require": [
+      "babel-register"
+    ],
+    "all": "true",
     "sourceMap": false,
-    "instrument": false
+    "instrument": false,
+    "include": [
+      "src/**/*.js"
+    ]
   }
 }


### PR DESCRIPTION
Fixes #828 by updating the nyc configuration.

This builds on the work of @IlyaRucavitcyn's [fork](https://github.com/IlyaRucavitcyn/react-redux/tree/Test-coverage-fix). Turns out the issue was the `npm test` command is setting the `BABEL_ENV` environment variable to `commonjs`, which doesn't have the required istanbul plugin.

To fix this, I just added the commonjs env plugin to the babel test environment and then switched `npm test` to use `BABEL_ENV=test`.

It now seems to produce an accurate coverage report and `coverage.lcov` is no longer empty after running `npm run coverage`.

<img width="619" alt="screen shot 2018-01-06 at 8 43 47 am" src="https://user-images.githubusercontent.com/5315170/34641768-d83556ac-f2bd-11e7-9f66-c4ddd5f4fd75.png">
