### PR TITLE
fix: optimize invariant message

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -90,7 +90,7 @@ export default function connectAdvanced(
     invariant(
       typeof WrappedComponent == 'function',
       `You must pass a component to the function returned by ` +
-      `connect. Instead received ${JSON.stringify(WrappedComponent)}`
+      `${methodName}. Instead received ${JSON.stringify(WrappedComponent)}`
     )
 
     const wrappedComponentName = WrappedComponent.displayName


### PR DESCRIPTION
Utilizing `methodName` option in invariant messages