### PR TITLE
fix: using forceUpdate() instead of setting dummyState

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -6,7 +6,6 @@ import Subscription from '../utils/Subscription'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
 
 let hotReloadingVersion = 0
-const dummyState = {}
 function noop() {}
 function makeSelectorStateful(sourceSelector, store) {
   // wrap the selector in an object that tracks its results between runs.
@@ -215,7 +214,7 @@ export default function connectAdvanced(
           this.notifyNestedSubs()
         } else {
           this.componentDidUpdate = this.notifyNestedSubsOnComponentDidUpdate
-          this.setState(dummyState)
+          this.forceUpdate()
         }
       }
 


### PR DESCRIPTION
Using forceUpdate() instead of setState(dummyState) to trigger wrapped component update.