### PR TITLE
pass ownProps to areStatesEqual

### DIFF
--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -1,5 +1,5 @@
 import verifySubselectors from './verifySubselectors'
-  
+
 export function impureFinalPropsSelectorFactory(
   mapStateToProps,
   mapDispatchToProps,
@@ -64,7 +64,7 @@ export function pureFinalPropsSelectorFactory(
     const nextStateProps = mapStateToProps(state, ownProps)
     const statePropsChanged = !areStatePropsEqual(nextStateProps, stateProps)
     stateProps = nextStateProps
-    
+
     if (statePropsChanged)
       mergedProps = mergeProps(stateProps, dispatchProps, ownProps)
 
@@ -73,7 +73,7 @@ export function pureFinalPropsSelectorFactory(
 
   function handleSubsequentCalls(nextState, nextOwnProps) {
     const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps)
-    const stateChanged = !areStatesEqual(nextState, state)
+    const stateChanged = !areStatesEqual(nextState, state, nextOwnProps, ownProps)
     state = nextState
     ownProps = nextOwnProps
 


### PR DESCRIPTION
We have a use case when we need to use `areStatesEqual` and access `ownProps` at the same time. This PR solves the problem.

```js
function compareStates(paths = [], a, b) {
    return paths.filter((path) => {
        const valueA = get(a, path);
        const valueB = get(b, path);
        return valueA !== valueB;
    });
}

const mapStateToProps = ({
    data: {
        campaign,
    },
}, { data: { id } }) => {
    const campaigns = getEntities(campaign, 'client_id', id);
    return {
        campaigns,
    };
};

export default connect(mapStateToProps, null, null, {
    areStatesEqual(prevState, nextState, { id }) {
        const paths = ['data.campaign.by.client_id.${id}.ids'];
        const differentPaths = compareStates(paths, prevState, nextState);
        const areEqual = differentPaths.length === 0;
        if (!areEqual) {
            console.log('[!] %s are not equal', differentPaths.join());
        }
        return areEqual;
    },
})(Client);
```