### PR TITLE
Fix project links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "author": "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/gaearon/react-redux/issues"
+    "url": "https://github.com/reactjs/react-redux/issues"
   },
-  "homepage": "https://github.com/gaearon/react-redux",
+  "homepage": "https://github.com/reactjs/react-redux",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"


### PR DESCRIPTION
Some links were still referencing the old repo name (`gaearon/react-redux`). Not a huge issue since the old URL redirects, but might as well use the correct URL since some tools display these as-is to end users (eg. yarn via `yarn outdated`) which can potentially be confusing.