### PR TITLE
Probably more careful args check

### DIFF
--- a/src/connect/wrapMapToProps.js
+++ b/src/connect/wrapMapToProps.js
@@ -20,7 +20,7 @@ export function wrapMapToPropsConstant(getConstant) {
 export function getDependsOnOwnProps(mapToProps) {
   return (mapToProps.dependsOnOwnProps !== null && mapToProps.dependsOnOwnProps !== undefined)
     ? Boolean(mapToProps.dependsOnOwnProps)
-    : mapToProps.length !== 1
+    : mapToProps.length >= 2
 }
 
 // Used by whenMapStateToPropsIsFunction and whenMapDispatchToPropsIsFunction,


### PR DESCRIPTION
Previous, missed args in mapStateToProps was cause this method called when store updated or component props updated. But whether this behavior is necessary? What is the reason to re-invoket the function if it does not depend on the state or ownProps?