### PR TITLE
Fix dependency on loadsh-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4559,9 +4559,9 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -6918,7 +6918,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.0.4"
       }


### PR DESCRIPTION
Recent versions of lodash-es were affected by a bug in NPM where by it set the timestamps of files to sometime in the 1970's which causes a problem when trying to create a zip file of the `node_modules`

See the released issues here.
https://github.com/yarnpkg/yarn/issues/5577
https://github.com/lodash/lodash/issues/3714

Lodash was republished with a newer version of NPM which fixes this issue.
This PR update just contains the result of `npm update loads-es`
